### PR TITLE
Fix typos in comments and documentation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -704,7 +704,7 @@ ChangeLog :
     - BUG/MINOR: listener: Don't decrease actconn twice when a new session is rejected
     - CLEANUP: map, stream: remove duplicate code in src/map.c, src/stream.c
     - BUG/MINOR: lua: the function returns anything
-    - BUG/MINOR: lua funtion hlua_socket_settimeout don't check negative values
+    - BUG/MINOR: lua function hlua_socket_settimeout don't check negative values
     - CLEANUP: lua: typo fix in comments
     - BUILD/MINOR: fix build when USE_THREAD is not defined
     - MINOR: lua: allow socket api settimeout to accept integers, float, and doubles
@@ -873,7 +873,7 @@ ChangeLog :
     - MINOR: systemd: consider exit status 143 as successful
     - REGTEST/MINOR: Wrong URI syntax.
     - CLEANUP: dns: remove obsolete macro DNS_MAX_IP_REC
-    - CLEANUP: dns: inacurate comment about prefered IP score
+    - CLEANUP: dns: inacurate comment about preferred IP score
     - MINOR: dns: fix wrong score computation in dns_get_ip_from_response
     - MINOR: dns: new DNS options to allow/prevent IP address duplication
     - REGTEST/MINOR: Unexpected curl URL globling.
@@ -1421,7 +1421,7 @@ ChangeLog :
     - MINOR: threads: Don't start when device a detection module is used
     - BUG/MEDIUM: threads: Run the poll loop on the main thread too
     - BUG/MINOR: threads: Add missing THREAD_LOCAL on static here and there
-    - MAJOR: threads: Offically enable the threads support in HAProxy
+    - MAJOR: threads: Officially enable the threads support in HAProxy
     - BUG/MAJOR: threads/freq_ctr: fix lock on freq counters.
     - BUG/MAJOR: threads/time: Store the time deviation in an 64-bits integer
     - BUILD: stick-tables: silence an uninitialized variable warning
@@ -1617,7 +1617,7 @@ ChangeLog :
     - BUG/MINOR: contrib/modsecurity: BSD build fix
     - BUG/MINOR: contrib/mod_defender: build fix
     - BUG/MINOR: ssl: remove haproxy SSLv3 support when ssl lib have no SSLv3
-    - MINOR: ssl: remove an unecessary SSL_OP_NO_* dependancy
+    - MINOR: ssl: remove an unnecessary SSL_OP_NO_* dependency
     - BUILD: ssl: fix compatibility with openssl without TLSEXT_signature_*
     - MINOR: tools: add a portable timegm() alternative
     - BUILD: lua: replace timegm() with my_timegm() to fix build on Solaris 10
@@ -1668,7 +1668,7 @@ ChangeLog :
     - MINOR: dns: ability to use a SRV resolution for multiple backends
     - MINOR: dns: enable caching of responses for server set by a SRV record
     - MINOR: dns: new dns record type (RTYPE) for OPT
-    - MINOR: dns: enabled edns0 extension and make accpeted payload size tunable
+    - MINOR: dns: enabled edns0 extension and make accepted payload size tunable
     - MINOR: dns: default "hold obsolete" timeout set to 0
     - MINOR: chunks: add chunk_memcpy() and chunk_memcat()
     - MINOR: session: add a streams field to the session struct
@@ -1680,7 +1680,7 @@ ChangeLog :
     - BUG/MINOR: Wrong type used as argument for spoe_decode_buffer().
     - BUG/MINOR: dns: server set by SRV records stay in "no resolution" status
     - MINOR: dns: Maximum DNS udp payload set to 8192
-    - MINOR: dns: automatic reduction of DNS accpeted payload size
+    - MINOR: dns: automatic reduction of DNS accepted payload size
     - MINOR: dns: make SRV record processing more verbose
     - CLEANUP: dns: remove duplicated code in dns_resolve_recv()
     - CLEANUP: dns: remove duplicated code in dns_validate_dns_response()
@@ -1892,7 +1892,7 @@ ChangeLog :
     - BUG/MINOR: change header-declared function to static inline
     - REORG: spoe: move spoe_encode_varint / spoe_decode_varint from spoe to common
     - MINOR: Add binary encoding request header sample fetch
-    - MINOR: proto-http: Add sample fetch wich returns all HTTP headers
+    - MINOR: proto-http: Add sample fetch which returns all HTTP headers
     - MINOR: Add ModSecurity wrapper as contrib
     - BUG/MINOR: ssl: fix warnings about methods for opensslv1.1.
     - DOC: update RFC references
@@ -2266,7 +2266,7 @@ ChangeLog :
     - DOC: fix parenthesis and add missing "Example" tags
     - DOC: update the contributing file
     - DOC: log-format/tcplog/httplog update
-    - MINOR: config parsing: add warning when log-format/tcplog/httplog is overriden in "defaults" sections
+    - MINOR: config parsing: add warning when log-format/tcplog/httplog is overridden in "defaults" sections
 
 2016/11/25 : 1.8-dev0
 
@@ -2446,7 +2446,7 @@ ChangeLog :
     - MINOR: cfgparse: few memory leaks fixes.
     - MEDIUM: log: Decompose %Tq in %Th %Ti %TR
     - CLEANUP: logs: remove unused log format field definitions
-    - BUILD/MAJOR:updated 51d Trie implementation to incorperate latest update to 51Degrees.c
+    - BUILD/MAJOR:updated 51d Trie implementation to incorporate latest update to 51Degrees.c
     - BUG/MAJOR: stream: properly mark the server address as unset on connect retry
     - CLEANUP: proto_http: Removing useless variable assignation
     - CLEANUP: dumpstats: Removing useless variables allocation
@@ -2989,7 +2989,7 @@ ChangeLog :
     - BUG/MINOR: Handle interactive mode in cli handler
     - DOC: global section missing parameters
     - DOC: backend section missing parameters
-    - DOC: stats paramaters available in frontend
+    - DOC: stats parameters available in frontend
     - MINOR: lru: do not allocate useless memory in lru64_lookup
     - BUG/MINOR: http: Add OPTIONS in supported http methods (found by find_http_meth)
     - BUG/MINOR: ssl: fix management of the cache where forged certificates are stored
@@ -3043,7 +3043,7 @@ ChangeLog :
     - MINOR: lua: rename the tune.lua.applet-timeout
     - DOC: lua: update Lua doc
     - DOC: lua: update doc according with the last Lua changes
-    - MINOR: http/tcp: fill the avalaible actions
+    - MINOR: http/tcp: fill the available actions
     - DOC: reorder misplaced res.ssl_hello_type in the doc
     - BUG/MINOR: tcp: make silent-drop always force a TCP reset
     - CLEANUP: tcp: silent-drop: only drain the connection when quick-ack is disabled
@@ -3261,7 +3261,7 @@ ChangeLog :
     - MINOR: samples: data assignation simplification
     - MEDIUM: pattern/map: Maps can returns various types
     - MINOR: map: The map can return IPv4 and IPv6
-    - MEDIUM: actions: Merge (http|tcp)-(request|reponse) action structs
+    - MEDIUM: actions: Merge (http|tcp)-(request|response) action structs
     - MINOR: actions: Remove the data opaque pointer
     - MINOR: lua: use the hlua_rule type in place of opaque type
     - MINOR: vars: use the vars types as argument in place of opaque type
@@ -3276,7 +3276,7 @@ ChangeLog :
     - MINOR: actions: Declare all the embedded actions in the same header file
     - MINOR: actions: change actions names
     - MEDIUM: actions: Add standard return code for the action API
-    - MEDIUM: actions: Merge (http|tcp)-(request|reponse) keywords structs
+    - MEDIUM: actions: Merge (http|tcp)-(request|response) keywords structs
     - MINOR: proto_tcp: proto_tcp.h is now useles
     - MINOR: actions: mutualise the action keyword lookup
     - MEDIUM: actions: Normalize the return code of the configuration parsers
@@ -3287,7 +3287,7 @@ ChangeLog :
     - MEDIUM: stick-tables: Add GPT0 in the stick tables
     - MINOR: stick-tables: Add GPT0 access
     - MINOR: stick-tables: Add GPC0 actions
-    - BUG/MEDIUM: lua: the lua fucntion Channel:close() causes a segfault
+    - BUG/MEDIUM: lua: the lua function Channel:close() causes a segfault
     - DOC: ssl: missing LF
     - MINOR: lua: add core.done() function
     - DOC: fix function name
@@ -3491,7 +3491,7 @@ ChangeLog :
     - MINOR: http: split the url_param in two parts
     - CLEANUP: http: bad indentation
     - MINOR: http: add body_param fetch
-    - MEDIUM: http: url-encoded parsing function can run throught wrapped buffer
+    - MEDIUM: http: url-encoded parsing function can run thought wrapped buffer
     - DOC: http: req.body_param documentation
     - MINOR: proxy: custom capture declaration
     - MINOR: capture: add two "capture" converters
@@ -3910,7 +3910,7 @@ ChangeLog :
     - BUG/MEDIUM: lua: the execution timeout is ignored in yield case
     - DOC: lua: Lua configuration documentation
     - MINOR: lua: add the struct session in the lua channel struct
-    - BUG/MINOR: lua: set buffer if it is nnot avalaible.
+    - BUG/MINOR: lua: set buffer if it is nnot available.
     - BUG/MEDIUM: lua: reset flags before resuming execution
     - BUG/MEDIUM: lua: fix infinite loop about channel
     - BUG/MEDIUM: lua: the Lua process is not waked up after sending data on requests side
@@ -4215,7 +4215,7 @@ ChangeLog :
     - BUG/MEDIUM: regex: fix risk of buffer overrun in exp_replace()
     - MINOR: acl: set "str" as default match for strings
     - DOC: Add some precisions about acl default matching method
-    - MEDIUM: acl: strenghten the option parser to report invalid options
+    - MEDIUM: acl: strengthen the option parser to report invalid options
     - BUG/MEDIUM: config: a stats-less config crashes in 1.5-dev25
     - BUG/MINOR: checks: tcp-check must not stop on '\0' for binary checks
     - MINOR: stats: improve alignment of color codes to save one line of header
@@ -5240,7 +5240,7 @@ ChangeLog :
     - BUG/MINOR: stats: http-request rules still don't cope with stats
     - BUG/MINOR: http: http-request add-header emits a corrupted header
     - BUG/MEDIUM: stats: disable request analyser when processing POST or HEAD
-    - BUG/MINOR: log: make log-format, unique-id-format and add-header more independant
+    - BUG/MINOR: log: make log-format, unique-id-format and add-header more independent
     - BUILD: log: unused variable svid
     - CLEANUP: http: rename the misleading http_check_access_rule
     - MINOR: http: move redirect rule processing to its own function
@@ -5431,7 +5431,7 @@ ChangeLog :
     - MINOR: ssl: add statement 'no-tls-tickets' on server side.
     - MINOR: ssl: add statements 'verify', 'ca-file' and 'crl-file' on servers.
     - DOC: Fix rename of options cafile and crlfile to ca-file and crl-file.
-    - MINOR: sample: manage binary to string type convertion in stick-table and samples.
+    - MINOR: sample: manage binary to string type conversion in stick-table and samples.
     - MINOR: acl: add parse and match primitives to use binary type on ACLs
     - MINOR: sample: export 'sample_get_trash_chunk(void)'
     - MINOR: conf: rename all ssl modules fetches using prefix 'ssl_fc' and 'ssl_c'
@@ -5691,7 +5691,7 @@ ChangeLog :
     - MINOR: ssl add global setting tune.sslcachesize to set SSL session cache size.
     - MEDIUM: ssl: add support for SNI and wildcard certificates
     - DOC: Typos cleanup
-    - DOC: fix name for "option independant-streams"
+    - DOC: fix name for "option independent-streams"
     - DOC: specify the default value for maxconn in the context of a proxy
     - BUG/MINOR: to_log erased with unique-id-format
     - LICENSE: add licence exception for OpenSSL
@@ -6240,7 +6240,7 @@ ChangeLog :
     - [BUG] peers: don't keep a peers section which has a NULL frontend
     - [BUG] peers: ensure the peers are resumed if they were paused
     - [MEDIUM] stats: add the ability to enable/disable/shutdown a frontend at runtime
-    - [MEDIUM] session: make session_shutdown() an independant function
+    - [MEDIUM] session: make session_shutdown() an independent function
     - [MEDIUM] stats: offer the possibility to kill a session from the CLI
     - [CLEANUP] stats: centralize tests for backend/server inputs on the CLI
     - [MEDIUM] stats: offer the possibility to kill sessions by server
@@ -6555,7 +6555,7 @@ ChangeLog :
     - [MEDIUM] stats: rely on the standard session_accept() function
     - [MINOR] buffer: refine the flags that may wake an analyser up.
     - [MINOR] stream_sock: don't dereference a non-existing frontend
-    - [MINOR] session: differenciate between accepted connections and received connections
+    - [MINOR] session: differentiate between accepted connections and received connections
     - [MEDIUM] frontend: count the incoming connection earlier
     - [MINOR] frontend: count denied TCP requests separately
     - [CLEANUP] stick_table: add/clarify some comments
@@ -6698,7 +6698,7 @@ ChangeLog :
 2010/03/17 : 1.4.2
     - [CLEANUP] product branch update
     - [DOC] Some more documentation cleanups
-    - [BUG] clf logs segfault when capturing a non existant header
+    - [BUG] clf logs segfault when capturing a non existent header
     - [OPTIM] config: only allocate check buffer when checks are enabled
     - [MEDIUM] checks: support multi-packet health check responses
     - [CLEANUP] session: remove duplicate test
@@ -6744,7 +6744,7 @@ ChangeLog :
     - [BUG] pxid/puid/luid: don't shift IDs when some of them are forced
     - [EXAMPLES] add auth.cfg
     - [BUG] uri_auth: ST_SHLGNDS should be 0x00000008 not 0x0000008
-    - [BUG] uri_auth: do not attemp to convert uri_auth -> http-request more than once
+    - [BUG] uri_auth: do not attempt to convert uri_auth -> http-request more than once
     - [BUILD] auth: don't use unnamed unions
     - [BUG] config: report unresolvable host names as errors
     - [BUILD] fix build breakage with DEBUG_FULL
@@ -6777,7 +6777,7 @@ ChangeLog :
     - [MINOR] pattern: add the "ipmask()" converting function
     - [MINOR] config: off-by-one in "stick-table" after list of converters
     - [CLEANUP] acl, patterns: make use of my_strndup() instead of malloc+memcpy
-    - [BUG] restore accidentely removed line in last patch !
+    - [BUG] restore accidently removed line in last patch !
     - [MINOR] checks: make the HTTP check code add the CRLF itself
     - [MINOR] checks: add the server's status in the checks
     - [BUILD] halog: make without arch-specific optimizations
@@ -7043,7 +7043,7 @@ ChangeLog :
     - [MEDIUM] backend: introduce the "static-rr" LB algorithm
     - [MINOR] report list of supported pollers with -vv
     - [DOC] log-health-checks is an option, not a directive
-    - [MEDIUM] new option "independant-streams" to stop updating read timeout on writes
+    - [MEDIUM] new option "independent-streams" to stop updating read timeout on writes
     - [BUG] stats: don't call buffer_shutw(), but ->shutw() instead
     - [MINOR] stats: strip CR and LF from the input command line
     - [BUG] don't refresh timeouts late after detected activity
@@ -7632,7 +7632,7 @@ ChangeLog :
     - [BUILD] ensure that makefile understands USE_DLMALLOC=1
     - [MINOR] silent gcc for a wrong warning
     - [CLEANUP] update .gitignore to ignore more temporary files
-    - [CLEANUP] report dlmalloc's source path only if explictly specified
+    - [CLEANUP] report dlmalloc's source path only if explicitly specified
     - [BUG] str2sun could leak a small buffer in case of error during parsing
     - [BUG] option allbackups was not working anymore in roundrobin mode
     - [MAJOR] implementation of the "leastconn" load balancing algorithm
@@ -7654,7 +7654,7 @@ ChangeLog :
     - use backends only with use_backend directive (Krzysztof Oledzki)
     - Handle long lines properly (Krzysztof Oledzki)
     - Implement and use generic findproxy and relax duplicated proxy check (Krzysztof Oledzki)
-    - continous statistics (Krzysztof Oledzki)
+    - continuous statistics (Krzysztof Oledzki)
     - add support for logging via a UNIX socket (Robert Tsai)
     - fix error checking in strl2ic/strl2uic()
     - fix calls to localtime()
@@ -7781,7 +7781,7 @@ ChangeLog :
     - errorfile: use a local file to feed error messages
     - acl: support '-i' to ignore case when matching
     - acl: smarter integer comparison with operators eq,lt,gt,le,ge
-    - acl: support maching on 'path' component
+    - acl: support machine on 'path' component
     - acl: implement matching on header values
     - acl: distinguish between request and response headers
     - acl: permit to return any header when no name specified
@@ -7826,7 +7826,7 @@ ChangeLog :
     - several fixes in ev_sepoll
     - fixed some expiration dates on some tasks
     - fixed a bug in connection establishment detection due to speculative I/O
-    - fixed rare bug occuring on TCP with early close (reported by Andy Smith)
+    - fixed rare bug occurring on TCP with early close (reported by Andy Smith)
     - implemented URI hashing algorithm (Guillaume Dallaire)
     - implemented SMTP health checks (Peter van Dijk)
     - replaced the rbtree with ul2tree from old scheduler project
@@ -7843,7 +7843,7 @@ ChangeLog :
       of macros at many places
     - implemented support for FreeBSD's kqueue() polling mechanism
     - fixed a warning on OpenBSD : MIN/MAX redefined
-    - change socket registration order at startup to accomodate kqueue.
+    - change socket registration order at startup to accommodate kqueue.
     - several makefile cleanups to support old shells
     - fix build with limits.h once for all
     - ev_epoll: do not rely on fd_sets anymore, use changes stacks instead.
@@ -7944,7 +7944,7 @@ ChangeLog :
      at once.
 
 2006/06/29 : 1.3.0
-   - exploded the whole file into multiple .c and .h. No functionnal
+   - exploded the whole file into multiple .c and .h. No functional
      difference is expected at all.
    - fixed a bug by which neither stats nor error messages could be returned if
      'clitimeout' was missing.
@@ -8153,7 +8153,7 @@ ChangeLog :
   - added a 'linux24e' target to the Makefile for Linux 2.4 systems patched to
     support epoll().
   - changed default FD_SETSIZE to 65536 on Solaris (default=1024)
-  - conditionned signals redirection to #ifdef DEBUG_MEMORY
+  - conditioned signals redirection to #ifdef DEBUG_MEMORY
 
 2005/04/26 : 1.2.5-pre4
   - made epoll() support a compile-time option : ENABLE_EPOLL

--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -429,7 +429,7 @@ do not think about them anymore after a few patches.
        $ git log --oneline 827752e.. | grep 'BUG\|DOC'
        0d79cf6 DOC: fix function name
        bc96534 DOC: ssl: missing LF
-       10ec214 BUG/MEDIUM: lua: the lua fucntion Channel:close() causes a segf
+       10ec214 BUG/MEDIUM: lua: the lua function Channel:close() causes a segf
        bdc97a8 BUG/MEDIUM: lua: outgoing connection was broken since 1.6-dev2
        ba56d9c DOC: mention support for RFC 5077 TLS Ticket extension in start
        f1650a8 DOC: clarify some points about SSL and the proxy protocol

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 #   [g]make TARGET=os ARCH=arch CPU=cpu USE_xxx=1 ...
 #
 # Valid USE_* options are the following. Most of them are automatically set by
-# the TARGET, others have to be explictly specified :
+# the TARGET, others have to be explicitly specified :
 #   USE_DLMALLOC         : enable use of dlmalloc (see DLMALLOC_SRC)
 #   USE_EPOLL            : enable epoll() on Linux 2.6. Automatic.
 #   USE_KQUEUE           : enable kqueue() on BSD. Automatic.
@@ -236,7 +236,7 @@ CPU_CFLAGS.i686       = -O2 -march=i686
 CPU_CFLAGS.ultrasparc = -O6 -mcpu=v9 -mtune=ultrasparc
 CPU_CFLAGS            = $(CPU_CFLAGS.$(CPU))
 
-#### ARCH dependant flags, may be overriden by CPU flags
+#### ARCH dependant flags, may be overridden by CPU flags
 ARCH_FLAGS.32     = -m32
 ARCH_FLAGS.64     = -m64
 ARCH_FLAGS.i386   = -m32 -march=i386

--- a/README
+++ b/README
@@ -116,7 +116,7 @@ you don't want them on your systems. HAProxy is known to build correctly on all
 currently supported branches (0.9.8, 1.0.0, 1.0.1, 1.0.2 and 1.1.0 at the time
 of writing). Branch 1.0.2 is currently recommended for the best combination of
 features and stability. Asynchronous engines require OpenSSL 1.1.0 though. It's
-worth mentionning that some OpenSSL derivatives are also reported to work but
+worth mentioning that some OpenSSL derivatives are also reported to work but
 may occasionally break. Patches to fix them are welcome but please read the
 CONTRIBUTING file first.
 
@@ -189,7 +189,7 @@ which come in multiple flavors depending on the system and architecture :
       silently fail. Pthreads are enabled using USE_PTHREAD_PSHARED=1.
 
   Synchronization operations :
-    - internal spinlock : this mode is OS-independant, light but will not
+    - internal spinlock : this mode is OS-independent, light but will not
       scale well to many processes. However, accesses to the session cache
       are rare enough that this mode could certainly always be used. This
       is the default mode.

--- a/contrib/halog/halog.c
+++ b/contrib/halog/halog.c
@@ -876,7 +876,7 @@ int main(int argc, char **argv)
 
 #if defined(POSIX_FADV_SEQUENTIAL)
 	/* around 20% performance improvement is observed on Linux with this
-	 * on cold-cache. Surprizingly, WILLNEED is less performant. Don't
+	 * on cold-cache. Surprisingly, WILLNEED is less performant. Don't
 	 * use NOREUSE as it flushes the cache and prevents easy data
 	 * manipulation on logs!
 	 */

--- a/contrib/modsecurity/modsec_wrapper.c
+++ b/contrib/modsecurity/modsec_wrapper.c
@@ -130,7 +130,7 @@ static void modsec_log(void *obj, int level, char *str)
 	LOG(&null_worker, "%s", str);
 }
 
-/* This fucntion load the ModSecurity file. It returns -1 if the
+/* This function load the ModSecurity file. It returns -1 if the
  * initialisation fails.
  */
 int modsecurity_load(const char *file)
@@ -568,7 +568,7 @@ int modsecurity_process(struct worker *worker, struct modsecurity_parameters *pa
 		goto fail;
 	}
 
-	/* Stores HTTP body avalaible data in a bucket */
+	/* Stores HTTP body available data in a bucket */
 	data_bucket = apr_bucket_alloc(sizeof(*data_bucket), req->connection->bucket_alloc);
 	if (!data_bucket) {
 		errno = ENOMEM;

--- a/contrib/spoa_example/include/mini-clist.h
+++ b/contrib/spoa_example/include/mini-clist.h
@@ -57,7 +57,7 @@ struct list {
 #define LIST_NEXT(lh, pt, el) (LIST_ELEM((lh)->n, pt, el))
 
 
-/* returns a pointer of type <pt> to a structure preceeding the element
+/* returns a pointer of type <pt> to a structure preceding the element
  * which contains list head <lh>, which is known as element <el> in
  * struct pt.
  */

--- a/contrib/spoa_example/include/spop_functions.h
+++ b/contrib/spoa_example/include/spop_functions.h
@@ -124,7 +124,7 @@ spoe_encode_buffer(const char *str, size_t len, char **buf, char *end)
 /* Encode a buffer, possibly partially. It does the same thing than
  * 'spoe_encode_buffer', but if there is not enough space, it does not fail.
  * On success, it returns the number of copied bytes and <*buf> is moved after
- * the encoded value. If an error occured, it returns -1. */
+ * the encoded value. If an error occurred, it returns -1. */
 static inline int
 spoe_encode_frag_buffer(const char *str, size_t len, char **buf, char *end)
 {
@@ -176,7 +176,7 @@ spoe_decode_buffer(char **buf, char *end, char **str, uint64_t *len)
 
 /* Encode a typed data using value in <data> and type <type>. On success, it
  * returns the number of copied bytes and <*buf> is moved after the encoded
- * value. If an error occured, it returns -1.
+ * value. If an error occurred, it returns -1.
  *
  * If the value is too big to be encoded, depending on its type, then encoding
  * failed or the value is partially encoded. Only strings and binaries can be

--- a/contrib/wireshark-dissectors/peers/README
+++ b/contrib/wireshark-dissectors/peers/README
@@ -7,7 +7,7 @@ on Windows systems (could not be tested).
 
 1) File list
 -------------
- - packet-happp.c: source code for HAProxy Peers Procotol (HAPPP) dissection
+ - packet-happp.c: source code for HAProxy Peers Protocol (HAPPP) dissection
    support.
  - wireshark.happp.dissector.patch: a patch file for wireshark sources to enable HAPPP
    dissection support. Note that this patch file modifies only two files:

--- a/contrib/wireshark-dissectors/peers/packet-happp.c
+++ b/contrib/wireshark-dissectors/peers/packet-happp.c
@@ -792,7 +792,7 @@ static void dissect_happp_stkt_define_msg(tvbuff_t *tvb, packet_info *pinfo _U_,
 		return;
 
 	/*
-	 * According to the documentation, it is not our responsability
+	 * According to the documentation, it is not our responsibility
 	 * to free this allocated memory.
 	 */
 	happp_cv_data = (struct happp_cv_data_t *)wmem_alloc(wmem_file_scope(),
@@ -1599,7 +1599,7 @@ dissect_happp_heur_tcp(tvbuff_t *tvb, packet_info *pinfo, proto_tree *tree, void
 	if (tvb_captured_length(tvb) < proto_strlen + 1)
 		return FALSE;
 
-	/* Check that we received a line begining with HAPPP_PROTOCOL
+	/* Check that we received a line beginning with HAPPP_PROTOCOL
 	 * followed by a space character.
 	 */
 	if (tvb_strneql(tvb, 0, HAPPP_PROTOCOL, proto_strlen) ||

--- a/doc/51Degrees-device-detection.txt
+++ b/doc/51Degrees-device-detection.txt
@@ -87,7 +87,7 @@ Here, two headers are created with 51Degrees data, X-51D-DeviceTypeMobileTablet
 and X-51D-Tablet. Any number of headers can be created this way and can be
 named anything. 51d.all( ) invokes the 51degrees fetch. It can be passed up to
 five property names of values to return. Values will be returned in the same
-order, seperated by the 51-degrees-property-separator configured earlier. If a
+order, separated by the 51-degrees-property-separator configured earlier. If a
 property name can't be found the value 'NoData' is returned instead.
 
 In addition to the device properties three additional properties related to the

--- a/doc/SPOE.txt
+++ b/doc/SPOE.txt
@@ -146,7 +146,7 @@ found in the SPOE configuration file. All the file is considered to be in the
 same anonymous and implicit scope.
 
 The engine name must be uniq for a proxy. If no engine name is provided on the
-SPOE filter line, the SPOE agent name is unsed by default.
+SPOE filter line, the SPOE agent name is unset by default.
 
 2.2. "spoe-agent" section
 --------------------------
@@ -192,7 +192,7 @@ groups <grp-name> ...
   Arguments :
     <grp-name>   is the name of a SPOE group.
 
-  Groups delcared here must be found in the same engine scope, else an error is
+  Groups declared here must be found in the same engine scope, else an error is
   triggered during the configuration parsing. You can have many "groups" lines.
 
   See also: "spoe-group" section.
@@ -501,7 +501,7 @@ args [name=]<sample> ...
 
   When the message is processed, if a sample expression is not available, it is
   set to NULL. Arguments are processed in their declaration order and added in
-  the message in that order. It is possible to declare named arguements.
+  the message in that order. It is possible to declare named arguments.
 
   For example:
     args frontend=fe_id src dst
@@ -717,7 +717,7 @@ actions.
            payload. When it is set, the FIN bit must also be set.
 
 
-Frames cannot exceed a maximum size negociated between HAProxy and agents
+Frames cannot exceed a maximum size negotiated between HAProxy and agents
 during the HELLO handshake. Most of time, payload will be small enough to send
 it in one frame. But when supported by the peer, it will be possible to
 fragment huge payload on many frames. This ability is announced during the
@@ -1182,7 +1182,7 @@ IMPORTANT NOTE: By default, for a specific stream, when an abnormal/unexpected
                 will disable it for the transaction (request and response).
                 See 'option continue-on-error' to bypass this limitation.
 
-To avoid a stream to wait infinitly, you must carefully choose the
+To avoid a stream to wait infinity, you must carefully choose the
 acknowledgement timeout. In most of cases, it will be quiet low. But it depends
 on the responsivness of your service.
 
@@ -1219,7 +1219,7 @@ following format:
                  fragmented frames, it is the sum of all fragments.
         * qT   : the delay before the request gets out the sending queue. For
                  fragmented frames, it is the sum of all fragments.
-        * wT   : the delay before the reponse is received. No fragmentation
+        * wT   : the delay before the response is received. No fragmentation
                  supported here.
         * resT : the delay to process the response. No fragmentation supported
                  here.

--- a/doc/architecture.txt
+++ b/doc/architecture.txt
@@ -509,7 +509,7 @@ Since haproxy does not handle SSL, this part will have to be extracted from the
 servers (freeing even more resources) and installed on the load-balancer
 itself. Install haproxy and apache+mod_ssl on the old box which will spread the
 load between the new boxes. Apache will work in SSL reverse-proxy-cache. If the
-application is correctly developped, it might even lower its load. However,
+application is correctly developed, it might even lower its load. However,
 since there now is a cache between the clients and haproxy, some security
 measures must be taken to ensure that inserted cookies will not be cached.
 

--- a/doc/close-options.txt
+++ b/doc/close-options.txt
@@ -10,7 +10,7 @@ FC = "forceclose".
 Options can be split between frontend and backend, so some of them might have
 a meaning only when combined by associating a frontend to a backend. Some forms
 are not the normal ones and provide a behaviour compatible with another normal
-form. Those are considered alternate forms and are markes "(alt)".
+form. Those are considered alternate forms and are marks "(alt)".
 
 FC SC HC PK    Behaviour
  0  0  0  X    tunnel mode

--- a/doc/coding-style.txt
+++ b/doc/coding-style.txt
@@ -525,7 +525,7 @@ parenthesis so it is sometimes followed by spaces and sometimes not when
 there are no parenthesis. Most people do not really care as long as what
 is written is unambiguous.
 
-Braces opening a block must be preceeded by one space unless the brace is
+Braces opening a block must be preceded by one space unless the brace is
 placed on the first column :
 
 Right :
@@ -811,7 +811,7 @@ common to see such a thing :
   | if ((fd = open(file, O_RDONLY)) < 0)
   |         return -1;
 
-This is wrong. The man page says that -1 is returned if an error occured. It
+This is wrong. The man page says that -1 is returned if an error occurred. It
 does not suggest that any other negative value will be an error. It is possible
 that a few such issues have been left in existing code. They are bugs for which
 fixes are accepted, eventhough they're currently harmless since open() is not
@@ -853,7 +853,7 @@ the first value even if it's zero. The last element should be followed by a
 comma if it is planned that new elements might later be added, this will make
 later patches shorter. Conversely, if the last element is placed in order to
 get the number of possible values, it must not be followed by a comma and must
-be preceeded by a comment :
+be preceded by a comment :
 
   | enum {
   |         first = 0,

--- a/doc/configuration.txt
+++ b/doc/configuration.txt
@@ -11146,7 +11146,7 @@ proto <name>
   in haproxy -vv.
   Idea behind this optipon is to bypass the selection of the best multiplexer's
   protocol for all connections instantiated from this listening socket. For
-  instance, it is possible to force the http/2 on clear TCP by specifing "proto
+  instance, it is possible to force the http/2 on clear TCP by specifying "proto
   h2" on the bind line.
 
 ssl

--- a/doc/cookie-options.txt
+++ b/doc/cookie-options.txt
@@ -13,7 +13,7 @@ PSV PFX INS REW IND   Behaviour
  0   0   1   0   1    insert + indirect : remove req and also resp if not needed
  *   *   1   1   *    [ forbidden ]
  0   1   0   0   0    prefix
- 0   1   0   0   1    !! prefix on request, remove reponse cookie if not needed
+ 0   1   0   0   1    !! prefix on request, remove response cookie if not needed
  *   1   *   1   *    [ forbidden ]
  *   1   1   *   *    [ forbidden ]
  *   *   *   1   1    [ forbidden ]

--- a/doc/design-thoughts/entities-v2.txt
+++ b/doc/design-thoughts/entities-v2.txt
@@ -61,7 +61,7 @@ On the accept() side, we probably need to know :
   - if a data-layer accept() has been performed
     => possibly 2 bits, to indicate the need to free()
 
-On the connect() side, we need to konw :
+On the connect() side, we need to know :
   - the desire to send a header (eg: send-proxy)
   - if this header has been sent
     => maybe both info might be combined

--- a/doc/design-thoughts/http2.txt
+++ b/doc/design-thoughts/http2.txt
@@ -117,7 +117,7 @@
   frame size minimum. That means slightly more than 16kB of buffer in each
   direction to process any frame. It will definitely have an impact on the
   deployed maxconn setting in places using less than this (4..8kB are common).
-  Also, the header list is persistant per connection, so if we reach the same
+  Also, the header list is persistent per connection, so if we reach the same
   size as the request, that's another 16kB in each direction, resulting in
   about 48kB of memory where 8 were previously used. A more careful encoder
   can work with a much smaller set even if that implies evicting entries
@@ -216,7 +216,7 @@ have dynamic buffer allocation.
 
 Thus :
 - Tx buffers do not exist. We allocate a buffer on the fly when we're ready to
-  send something that we need to build and that needs to be persistant in case
+  send something that we need to build and that needs to be persistent in case
   of partial send. H1 headers are built on the fly from the header table to a
   temporary buffer that is immediately sent and whose amount of sent bytes is
   the only information kept (like for PROXY protocol). H2 headers are more

--- a/doc/internals/body-parsing.txt
+++ b/doc/internals/body-parsing.txt
@@ -81,7 +81,7 @@ msg.sov  : start of value. First character of the header's value in the header
 
 msg.sol  : start of line. Points to the beginning of the current header line
            while parsing headers. It is cleared to zero in the BODY state,
-           and contains exactly the number of bytes comprising the preceeding
+           and contains exactly the number of bytes comprising the preceding
            chunk size in the DATA state (which can be zero), so that the sum of
            msg.sov + msg.sol always points to the beginning of data for all
            states starting with DATA. For chunked encoded messages, this sum
@@ -91,7 +91,7 @@ msg.sol  : start of line. Points to the beginning of the current header line
            TRAILERS state, it contains the length of the last parsed part of
            the trailer headers.
 
-msg.eoh  : end of headers. Points to the CRLF (or LF) preceeding the body and
+msg.eoh  : end of headers. Points to the CRLF (or LF) preceding the body and
            marking the end of headers. It is where new headers are appended.
            This offset is automatically adjusted when inserting/removing some
            headers. It always contains the size of the headers excluding the

--- a/doc/internals/connection-header.txt
+++ b/doc/internals/connection-header.txt
@@ -180,7 +180,7 @@ CLO    1.1      both      any       CLO       del_ka
     on versions and current connection header(s).
 
   - both CLO and TUN modes work similarly, they need to set a close mode on the
-    reponse. A 1.1 response will exclusively need the close header, while a 1.0
+    response. A 1.1 response will exclusively need the close header, while a 1.0
     response will have it removed. Any keep-alive header is always removed when
     found.
 

--- a/doc/internals/entities-v2.txt
+++ b/doc/internals/entities-v2.txt
@@ -58,7 +58,7 @@ On the accept() side, we probably need to know :
   - if a data-layer accept() has been performed
     => possibly 2 bits, to indicate the need to free()
 
-On the connect() side, we need to konw :
+On the connect() side, we need to know :
   - the desire to send a header (eg: send-proxy)
   - if this header has been sent
     => maybe both info might be combined

--- a/doc/internals/entities.txt
+++ b/doc/internals/entities.txt
@@ -68,7 +68,7 @@ which takes decisions.
 Connector
 ---------
 
-A connector is the entity which permits to instanciate a connection to a known
+A connector is the entity which permits to instantiate a connection to a known
 destination. It presents a connect() callback, and as such appears on the right
 side of diagrams.
 

--- a/doc/internals/filters.txt
+++ b/doc/internals/filters.txt
@@ -293,8 +293,8 @@ instances attached to a stream:
                                              * If NULL, we start from the first filter.
                                              * 0: request channel, 1: response channel */
         unsigned short flags;               /* STRM_FL_* */
-        unsigned char  nb_req_data_filters; /* Number of data filters registerd on the request channel */
-        unsigned char  nb_rsp_data_filters; /* Number of data filters registerd on the response channel */
+        unsigned char  nb_req_data_filters; /* Number of data filters registered on the request channel */
+        unsigned char  nb_rsp_data_filters; /* Number of data filters registered on the response channel */
     };
 
 
@@ -544,7 +544,7 @@ silently ignored (in this case, global.nbthread will be always equal to one).
 3.4. HANDLING THE STREAMS ACTIVITY
 -----------------------------------
 
-You may be interessted to handle streams activity. For now, there is three
+You may be interested to handle streams activity. For now, there is three
 callbacks that you should define to do so:
 
   * 'flt_ops.stream_start': It is called when a stream is started. This callback

--- a/doc/internals/notes-layers.txt
+++ b/doc/internals/notes-layers.txt
@@ -9,7 +9,7 @@
     available via conn_streams, sends data to the network
 
 
-The connection zone contains multiple layers which behave independantly in each
+The connection zone contains multiple layers which behave independently in each
 direction. The Rx direction is activated upon callbacks from the lower layers.
 The Tx direction is activated recursively from the upper layers. Between every
 two layers there may be a buffer, in each direction. When a buffer is full
@@ -82,7 +82,7 @@ Some operation flags will be needed on cs_recv() :
     requested size, thus no need to re-enable receiving on the lower layers.
 
   - RECV_ONE_SHOT : perform a single read without re-enabling reading on the
-    lower layers, like we currently do when receving an HTTP/1 request. Like
+    lower layers, like we currently do when receiving an HTTP/1 request. Like
     RECV_ENOUGH where any size is enough. Probably that the two could be merged
     (eg: by having a MIN argument like RECV_MIN).
 
@@ -99,7 +99,7 @@ Some operation flags will be needed on cs_send() :
 
 
 Both operations should return a composite status :
-  - number of bytes transfered
+  - number of bytes transferred
   - status flags (shutr, shutw, reset, empty, full, ...)
 
 

--- a/doc/lua-api/index.rst
+++ b/doc/lua-api/index.rst
@@ -1838,7 +1838,7 @@ Socket class
 
   Other format accepted are a socket path like "/socket/path", it permits to
   connect to a socket. Abstract namespaces are supported with the prefix
-  "abns@", and finaly a file descriptor can be passed with the prefix "fd@".
+  "abns@", and finally a file descriptor can be passed with the prefix "fd@".
   The prefix "ipv4@", "ipv6@" and "unix@" are also supported. The port can be
   passed int the string. The syntax "127.0.0.1:1234" is valid. In this case, the
   parameter *port* must not be set.

--- a/doc/lua.txt
+++ b/doc/lua.txt
@@ -35,7 +35,7 @@ Their need is to have an embedded programming language in order to no longer
 modify the HAProxy source code, but to write their own control code. Lua is
 encountered very often in the software industry, and in some open source
 projects. It is easy to understand, efficient, light without external
-dependancies, and leaves the resource control to the implementation. Its design
+dependencies, and leaves the resource control to the implementation. Its design
 is close to the HAProxy philosophy which uses components for what they do
 perfectly.
 
@@ -473,7 +473,7 @@ stores a stack state, and the longjmp restores the stack in its state which had
 before the last Lua execution.
 
 Lua can immediately stop its execution if an error occurs. This system uses also
-the longjmp system. In HAProxy, we try to use this sytem only for unrecoverable
+the longjmp system. In HAProxy, we try to use this system only for unrecoverable
 errors. Maybe some trivial errors target an exception, but we try to remove it.
 
 It seems that Lua uses the longjmp system for having a behaviour like the java
@@ -917,7 +917,7 @@ without storing again the new table. Maybe an example will be clearer:
 HTTP actions
 ============
 
-   ... comming soon ...
+   ... coming soon ...
 
 Lua is fast, but my service require more execution speed
 ========================================================

--- a/doc/management.txt
+++ b/doc/management.txt
@@ -1286,7 +1286,7 @@ example :
     # echo "show info;show stat;show table" | socat /var/run/haproxy stdio
 
 If a command needs to use a semi-colon or a backslash (eg: in a value), it
-must be preceeded by a backslash ('\').
+must be preceded by a backslash ('\').
 
 The interactive mode displays a prompt ('>') and waits for commands to be
 entered on the line, then processes them, and displays the prompt again to wait

--- a/doc/peers-v2.0.txt
+++ b/doc/peers-v2.0.txt
@@ -110,7 +110,7 @@ Available message Types for this class are:
 
 a) Protocol Message
 
-To signal that a protocol error occured. Connection will be shutdown just after sending this message.
+To signal that a protocol error occurred. Connection will be shutdown just after sending this message.
 
 b) Size Limit Error Message
 
@@ -248,9 +248,9 @@ Encoded Remote Table Id | Update Id
 
 
 Remote Table Id is the numeric identifier of the table on the remote side.
-Update Id is the id of the last update locally commited.
+Update Id is the id of the last update locally committed.
 
-If a re-connection occured, the sender should know he will have to restart the push of updates from this point.
+If a re-connection occurred, the sender should know he will have to restart the push of updates from this point.
 
 III) Initial full resync process.
 

--- a/doc/peers.txt
+++ b/doc/peers.txt
@@ -118,13 +118,13 @@
            return bitf
 
        set the next byte of bitf to the value of val OR'ed with 0xf0
-       substract 0xf0 from val
+       subtract 0xf0 from val
        right shift val by 4
 
        while val bit 7 is set (or if val is greater or equal to 0x80):
            set the next byte of bitf to the value of the byte made of the last
                7 bits of val OR'ed with 0x80
-           substract 0x80 from val
+           subtract 0x80 from val
            right shift val by 7
 
        set the next byte of bitf to the value of val
@@ -152,7 +152,7 @@
      "set the next byte of bitf to the value of val OR'ed with 0xf0"
      => bitf[0] = (0x1234 | 0xf0) & 0xff = 0xf4
 
-     "substract 0xf0 from val"
+     "subtract 0xf0 from val"
      => val = 0x1144
 
      right shift val by 4
@@ -162,7 +162,7 @@
      7 bits of val OR'ed with 0x80"
      => bitf[1] = (0x114 | 0x80) & 0xff = 0x94
 
-     "substract 0x80 from val"
+     "subtract 0x80 from val"
      => val= 0x94
 
      "right shift val by 7"
@@ -292,7 +292,7 @@
      entry update messages for different stick-tables may be sent over the same
      peer session.
 
-     To do so, each time entry update messages have to sent, they must be preceeded
+     To do so, each time entry update messages have to sent, they must be preceded
      by a stick-table definition message. This remains true for incremental entry
      update messages.
 

--- a/doc/regression-testing.txt
+++ b/doc/regression-testing.txt
@@ -264,7 +264,7 @@ file.
       cat ${tmpdir}/h1/cfg
     }
 
-We give only the ouput of the shell to illustrate this example:
+We give only the output of the shell to illustrate this example:
 
     .
     .
@@ -382,7 +382,7 @@ below.
     #    requiring LW_BYTES is set), the log is emitted after the connection is
     #    closed, so the address and ports cannot be retrieved anymore.
     #
-    #    It could be argued that we'd make a special case of these to immediatly
+    #    It could be argued that we'd make a special case of these to immediately
     #    retrieve the source and destination addresses from the connection, but it
     #    seems cleaner to simply pin the front connection, marking it "tracked" by
     #    adding the LW_XPRT flag to mention that we'll need some of these elements

--- a/ebtree/eb32tree.h
+++ b/ebtree/eb32tree.h
@@ -129,7 +129,7 @@ static forceinline void __eb32_delete(struct eb32_node *eb32)
 }
 
 /*
- * Find the first occurence of a key in the tree <root>. If none can be
+ * Find the first occurrence of a key in the tree <root>. If none can be
  * found, return NULL.
  */
 static forceinline struct eb32_node *__eb32_lookup(struct eb_root *root, u32 x)
@@ -180,7 +180,7 @@ static forceinline struct eb32_node *__eb32_lookup(struct eb_root *root, u32 x)
 }
 
 /*
- * Find the first occurence of a signed key in the tree <root>. If none can
+ * Find the first occurrence of a signed key in the tree <root>. If none can
  * be found, return NULL.
  */
 static forceinline struct eb32_node *__eb32i_lookup(struct eb_root *root, s32 x)

--- a/ebtree/eb64tree.h
+++ b/ebtree/eb64tree.h
@@ -129,7 +129,7 @@ static forceinline void __eb64_delete(struct eb64_node *eb64)
 }
 
 /*
- * Find the first occurence of a key in the tree <root>. If none can be
+ * Find the first occurrence of a key in the tree <root>. If none can be
  * found, return NULL.
  */
 static forceinline struct eb64_node *__eb64_lookup(struct eb_root *root, u64 x)
@@ -178,7 +178,7 @@ static forceinline struct eb64_node *__eb64_lookup(struct eb_root *root, u64 x)
 }
 
 /*
- * Find the first occurence of a signed key in the tree <root>. If none can
+ * Find the first occurrence of a signed key in the tree <root>. If none can
  * be found, return NULL.
  */
 static forceinline struct eb64_node *__eb64i_lookup(struct eb_root *root, s64 x)

--- a/ebtree/ebimtree.c
+++ b/ebtree/ebimtree.c
@@ -23,7 +23,7 @@
 #include "ebpttree.h"
 #include "ebimtree.h"
 
-/* Find the first occurence of a key of <len> bytes in the tree <root>.
+/* Find the first occurrence of a key of <len> bytes in the tree <root>.
  * If none can be found, return NULL.
  */
 REGPRM3 struct ebpt_node *

--- a/ebtree/ebimtree.h
+++ b/ebtree/ebimtree.h
@@ -35,7 +35,7 @@
 REGPRM3 struct ebpt_node *ebim_lookup(struct eb_root *root, const void *x, unsigned int len);
 REGPRM3 struct ebpt_node *ebim_insert(struct eb_root *root, struct ebpt_node *new, unsigned int len);
 
-/* Find the first occurence of a key of a least <len> bytes matching <x> in the
+/* Find the first occurrence of a key of a least <len> bytes matching <x> in the
  * tree <root>. The caller is responsible for ensuring that <len> will not exceed
  * the common parts between the tree's keys and <x>. In case of multiple matches,
  * the leftmost node is returned. This means that this function can be used to
@@ -89,7 +89,7 @@ __ebim_lookup(struct eb_root *root, const void *x, unsigned int len)
 		 */
 		node_bit = ~node_bit + (pos << 3) + 8; // = (pos<<3) + (7 - node_bit)
 		if (node_bit < 0) {
-			/* This surprizing construction gives better performance
+			/* This surprising construction gives better performance
 			 * because gcc does not try to reorder the loop. Tested to
 			 * be fine with 2.95 to 4.2.
 			 */

--- a/ebtree/ebistree.c
+++ b/ebtree/ebistree.c
@@ -22,7 +22,7 @@
 
 #include "ebistree.h"
 
-/* Find the first occurence of a zero-terminated string <x> in the tree <root>.
+/* Find the first occurrence of a zero-terminated string <x> in the tree <root>.
  * It's the caller's reponsibility to use this function only on trees which
  * only contain zero-terminated strings. If none can be found, return NULL.
  */

--- a/ebtree/ebistree.h
+++ b/ebtree/ebistree.h
@@ -38,7 +38,7 @@
 REGPRM2 struct ebpt_node *ebis_lookup(struct eb_root *root, const char *x);
 REGPRM2 struct ebpt_node *ebis_insert(struct eb_root *root, struct ebpt_node *new);
 
-/* Find the first occurence of a length <len> string <x> in the tree <root>.
+/* Find the first occurrence of a length <len> string <x> in the tree <root>.
  * It's the caller's reponsibility to use this function only on trees which
  * only contain zero-terminated strings, and that no null character is present
  * in string <x> in the first <len> chars. If none can be found, return NULL.
@@ -54,7 +54,7 @@ ebis_lookup_len(struct eb_root *root, const char *x, unsigned int len)
 	return node;
 }
 
-/* Find the first occurence of a zero-terminated string <x> in the tree <root>.
+/* Find the first occurrence of a zero-terminated string <x> in the tree <root>.
  * It's the caller's reponsibility to use this function only on trees which
  * only contain zero-terminated strings. If none can be found, return NULL.
  */

--- a/ebtree/ebmbtree.c
+++ b/ebtree/ebmbtree.c
@@ -22,7 +22,7 @@
 
 #include "ebmbtree.h"
 
-/* Find the first occurence of a key of <len> bytes in the tree <root>.
+/* Find the first occurrence of a key of <len> bytes in the tree <root>.
  * If none can be found, return NULL.
  */
 REGPRM3 struct ebmb_node *
@@ -42,7 +42,7 @@ ebmb_insert(struct eb_root *root, struct ebmb_node *new, unsigned int len)
 	return __ebmb_insert(root, new, len);
 }
 
-/* Find the first occurence of the longest prefix matching a key <x> in the
+/* Find the first occurrence of the longest prefix matching a key <x> in the
  * tree <root>. It's the caller's responsibility to ensure that key <x> is at
  * least as long as the keys in the tree. If none can be found, return NULL.
  */
@@ -52,7 +52,7 @@ ebmb_lookup_longest(struct eb_root *root, const void *x)
 	return __ebmb_lookup_longest(root, x);
 }
 
-/* Find the first occurence of a prefix matching a key <x> of <pfx> BITS in the
+/* Find the first occurrence of a prefix matching a key <x> of <pfx> BITS in the
  * tree <root>. If none can be found, return NULL.
  */
 REGPRM3 struct ebmb_node *

--- a/ebtree/ebmbtree.h
+++ b/ebtree/ebmbtree.h
@@ -123,7 +123,7 @@ static forceinline void __ebmb_delete(struct ebmb_node *ebmb)
 	__eb_delete(&ebmb->node);
 }
 
-/* Find the first occurence of a key of a least <len> bytes matching <x> in the
+/* Find the first occurrence of a key of a least <len> bytes matching <x> in the
  * tree <root>. The caller is responsible for ensuring that <len> will not exceed
  * the common parts between the tree's keys and <x>. In case of multiple matches,
  * the leftmost node is returned. This means that this function can be used to
@@ -176,7 +176,7 @@ static forceinline struct ebmb_node *__ebmb_lookup(struct eb_root *root, const v
 		 */
 		node_bit = ~node_bit + (pos << 3) + 8; // = (pos<<3) + (7 - node_bit)
 		if (node_bit < 0) {
-			/* This surprizing construction gives better performance
+			/* This surprising construction gives better performance
 			 * because gcc does not try to reorder the loop. Tested to
 			 * be fine with 2.95 to 4.2.
 			 */
@@ -371,7 +371,7 @@ __ebmb_insert(struct eb_root *root, struct ebmb_node *new, unsigned int len)
 }
 
 
-/* Find the first occurence of the longest prefix matching a key <x> in the
+/* Find the first occurrence of the longest prefix matching a key <x> in the
  * tree <root>. It's the caller's responsibility to ensure that key <x> is at
  * least as long as the keys in the tree. Note that this can be ensured by
  * having a byte at the end of <x> which cannot be part of any prefix, typically
@@ -465,7 +465,7 @@ static forceinline struct ebmb_node *__ebmb_lookup_longest(struct eb_root *root,
 }
 
 
-/* Find the first occurence of a prefix matching a key <x> of <pfx> BITS in the
+/* Find the first occurrence of a prefix matching a key <x> of <pfx> BITS in the
  * tree <root>. It's the caller's responsibility to ensure that key <x> is at
  * least as long as the keys in the tree. Note that this can be ensured by
  * having a byte at the end of <x> which cannot be part of any prefix, typically

--- a/ebtree/ebsttree.c
+++ b/ebtree/ebsttree.c
@@ -22,7 +22,7 @@
 
 #include "ebsttree.h"
 
-/* Find the first occurence of a zero-terminated string <x> in the tree <root>.
+/* Find the first occurrence of a zero-terminated string <x> in the tree <root>.
  * It's the caller's reponsibility to use this function only on trees which
  * only contain zero-terminated strings. If none can be found, return NULL.
  */

--- a/ebtree/ebsttree.h
+++ b/ebtree/ebsttree.h
@@ -32,7 +32,7 @@
 REGPRM2 struct ebmb_node *ebst_lookup(struct eb_root *root, const char *x);
 REGPRM2 struct ebmb_node *ebst_insert(struct eb_root *root, struct ebmb_node *new);
 
-/* Find the first occurence of a length <len> string <x> in the tree <root>.
+/* Find the first occurrence of a length <len> string <x> in the tree <root>.
  * It's the caller's reponsibility to use this function only on trees which
  * only contain zero-terminated strings, and that no null character is present
  * in string <x> in the first <len> chars. If none can be found, return NULL.
@@ -48,7 +48,7 @@ ebst_lookup_len(struct eb_root *root, const char *x, unsigned int len)
 	return node;
 }
 
-/* Find the first occurence of a zero-terminated string <x> in the tree <root>.
+/* Find the first occurrence of a zero-terminated string <x> in the tree <root>.
  * It's the caller's reponsibility to use this function only on trees which
  * only contain zero-terminated strings. If none can be found, return NULL.
  */

--- a/examples/errorfiles/500.http
+++ b/examples/errorfiles/500.http
@@ -4,6 +4,6 @@ Connection: close
 Content-Type: text/html
 
 <html><body><h1>500 Internal Server Error</h1>
-An internal server error occured.
+An internal server error occurred.
 </body></html>
 

--- a/examples/transparent_proxy.cfg
+++ b/examples/transparent_proxy.cfg
@@ -39,11 +39,11 @@ backend TransparentBack_http
 # /sbin/sysctl net.link.ether.ipfw=1
 # ipfw add 10 fwd localhost tcp from 192.168.0.40 80 to any in recv em0
 #
-# the above does the folowing:
+# the above does the following:
 # - load the ipfw kernal module
 # - set pf as the outer firewall to keep control of routing packets for example to route them to a non-default gateway
 # - enable ipfw
-# - set a rule to catches reply traffic on em0 comming from the webserver
+# - set a rule to catches reply traffic on em0 coming from the webserver
 #
 # --- Step 2 ---
 # To also make the client connection transparent its possible to redirect incomming requests to HAProxy with a pf rule:

--- a/include/common/chunk.h
+++ b/include/common/chunk.h
@@ -197,7 +197,7 @@ static inline int chunk_strncat(struct buffer *chk, const char *str, int nb)
 
 /* Adds a trailing zero to the current chunk and returns the pointer to the
  * following part. The purpose is to be able to use a chunk as a series of
- * short independant strings with chunk_* functions, which do not need to be
+ * short independent strings with chunk_* functions, which do not need to be
  * released. Returns NULL if no space is available to ensure that the new
  * string will have its own trailing zero. For example :
  *   chunk_init(&trash);

--- a/include/common/mini-clist.h
+++ b/include/common/mini-clist.h
@@ -107,7 +107,7 @@ struct cond_wordlist {
 #define LIST_NEXT(lh, pt, el) (LIST_ELEM((lh)->n, pt, el))
 
 
-/* returns a pointer of type <pt> to a structure preceeding the element
+/* returns a pointer of type <pt> to a structure preceding the element
  * which contains list head <lh>, which is known as element <el> in
  * struct pt.
  */

--- a/include/common/standard.h
+++ b/include/common/standard.h
@@ -365,7 +365,7 @@ extern const char *invalid_prefix_char(const char *name);
  * IPv6, use ":::port". NULL is returned if the host part cannot be resolved.
  * If <pfx> is non-null, it is used as a string prefix before any path-based
  * address (typically the path to a unix socket). If use_dns is not true,
- * the funtion cannot accept the DNS resolution.
+ * the function cannot accept the DNS resolution.
  */
 struct sockaddr_storage *str2sa_range(const char *str,
                                       int *port, int *low, int *high,
@@ -1055,10 +1055,10 @@ extern int in_net_ipv4(const void *addr, const struct in_addr *mask, const struc
 /* Return true if IPv6 address is part of the network */
 extern int in_net_ipv6(const void *addr, const struct in6_addr *mask, const struct in6_addr *net);
 
-/* Map IPv4 adress on IPv6 address, as specified in RFC 3513. */
+/* Map IPv4 address on IPv6 address, as specified in RFC 3513. */
 extern void v4tov6(struct in6_addr *sin6_addr, struct in_addr *sin_addr);
 
-/* Map IPv6 adress on IPv4 address, as specified in RFC 3513.
+/* Map IPv6 address on IPv4 address, as specified in RFC 3513.
  * Return true if conversion is possible and false otherwise.
  */
 extern int v6tov4(struct in_addr *sin_addr, struct in6_addr *sin6_addr);
@@ -1208,7 +1208,7 @@ const char *strnistr(const char *str1, int len_str1, const char *str2, int len_s
 /* after increasing a pointer value, it can exceed the first buffer
  * size. This function transform the value of <ptr> according with
  * the expected position. <chunks> is an array of the one or two
- * avalaible chunks. The first value is the start of the first chunk,
+ * available chunks. The first value is the start of the first chunk,
  * the second value if the end+1 of the first chunks. The third value
  * is NULL or the start of the second chunk and the fourth value is
  * the end+1 of the second chunk. The function returns 1 if does a

--- a/include/proto/connection.h
+++ b/include/proto/connection.h
@@ -871,7 +871,7 @@ static inline void list_mux_proto(FILE *out)
 	char *mode, *side;
 
 	fprintf(out, "Available multiplexer protocols :\n"
-		"(protocols markes as <default> cannot be specified using 'proto' keyword)\n");
+		"(protocols marked as <default> cannot be specified using 'proto' keyword)\n");
 	list_for_each_entry(item, &mux_proto_list.list, list) {
 		proto = item->token;
 

--- a/include/proto/h1.h
+++ b/include/proto/h1.h
@@ -179,7 +179,7 @@ static inline int h1_skip_chunk_crlf(const struct buffer *buf, int start, int st
 	const char *ptr = b_peek(buf, start);
 	int bytes = 1;
 
-	/* NB: we'll check data availabilty at the end. It's not a
+	/* NB: we'll check data availability at the end. It's not a
 	 * problem because whatever we match first will be checked
 	 * against the correct length.
 	 */

--- a/include/proto/log.h
+++ b/include/proto/log.h
@@ -149,12 +149,12 @@ int get_log_facility(const char *fac);
  * Write a string in the log string
  * Take cares of quote options
  *
- * Return the adress of the \0 character, or NULL on error
+ * Return the address of the \0 character, or NULL on error
  */
 char *lf_text_len(char *dst, const char *src, size_t len, size_t size, const struct logformat_node *node);
 
 /*
- * Write a IP adress to the log string
+ * Write a IP address to the log string
  * +X option write in hexadecimal notation, most signifant byte on the left
  */
 char *lf_ip(char *dst, const struct sockaddr *sockaddr, size_t size, const struct logformat_node *node);

--- a/include/proto/protocol.h
+++ b/include/proto/protocol.h
@@ -35,7 +35,7 @@ void protocol_register(struct protocol *proto);
  */
 void protocol_unregister(struct protocol *proto);
 
-/* binds all listeneres of all registered protocols. Returns a composition
+/* binds all listeners of all registered protocols. Returns a composition
  * of ERR_NONE, ERR_RETRYABLE, ERR_FATAL.
  */
 int protocol_bind_all(char *errmsg, int errlen);

--- a/include/proto/sample.h
+++ b/include/proto/sample.h
@@ -51,7 +51,7 @@ int smp_dup(struct sample *smp);
 
 /*
  * This function just apply a cast on sample. It returns 0 if the cast is not
- * avalaible or if the cast fails, otherwise returns 1. It does not modify the
+ * available or if the cast fails, otherwise returns 1. It does not modify the
  * input sample on failure.
  */
 static inline

--- a/include/proto/spoe.h
+++ b/include/proto/spoe.h
@@ -61,7 +61,7 @@ spoe_encode_buffer(const char *str, size_t len, char **buf, char *end)
 /* Encode a buffer, possibly partially. It does the same thing than
  * 'spoe_encode_buffer', but if there is not enough space, it does not fail.
  * On success, it returns the number of copied bytes and <*buf> is moved after
- * the encoded value. If an error occured, it returns -1. */
+ * the encoded value. If an error occurred, it returns -1. */
 static inline int
 spoe_encode_frag_buffer(const char *str, size_t len, char **buf, char *end)
 {
@@ -113,7 +113,7 @@ spoe_decode_buffer(char **buf, char *end, char **str, uint64_t *len)
 
 /* Encode a typed data using value in <smp>. On success, it returns the number
  * of copied bytes and <*buf> is moved after the encoded value. If an error
- * occured, it returns -1.
+ * occurred, it returns -1.
  *
  * If the value is too big to be encoded, depending on its type, then encoding
  * failed or the value is partially encoded. Only strings and binaries can be

--- a/include/types/checks.h
+++ b/include/types/checks.h
@@ -224,7 +224,7 @@ struct tcpcheck_rule {
 	/* match type uses NON-NULL pointer from either string or expect_regex below */
 	/* sent string is string */
 	char *string;                           /* sent or expected string */
-	int string_len;                         /* string lenght */
+	int string_len;                         /* string length */
 	struct my_regex *expect_regex;          /* expected */
 	int inverse;                            /* 0 = regular match, 1 = inverse match */
 	unsigned short port;                    /* port to connect to */

--- a/include/types/dns.h
+++ b/include/types/dns.h
@@ -88,7 +88,7 @@
 #define DNS_FLAG_TRUNCATED      0x0200  /* mask for truncated flag */
 #define DNS_FLAG_REPLYCODE      0x000F  /* mask for reply code */
 
-/* max number of network preference entries are avalaible from the
+/* max number of network preference entries are available from the
  * configuration file.
  */
 #define SRV_MAX_PREF_NET 5
@@ -244,7 +244,7 @@ struct dns_options {
 			struct in6_addr in6;
 		} mask;
 	} pref_net[SRV_MAX_PREF_NET];
-	int pref_net_nb; /* The number of registered prefered networks. */
+	int pref_net_nb; /* The number of registered preferred networks. */
 	int accept_duplicate_ip; /* flag to indicate whether the associated object can use an IP address
 				    already set to an other object of the same group */
 };
@@ -265,7 +265,7 @@ struct dns_resolution {
 	unsigned int          last_valid;          /* time of the last valid response */
 	int                   query_id;            /* DNS query ID dedicated for this resolution */
 	struct eb32_node      qid;                 /* ebtree query id */
-	int                   prefered_query_type; /* prefered query type */
+	int                   preferred_query_type; /* preferred query type */
 	int                   query_type;          /* current query type  */
 	int                   status;              /* status of the resolution being processed RSLV_STATUS_* */
 	int                   step;                /* RSLV_STEP_* */
@@ -292,7 +292,7 @@ struct dns_requester {
 
 /* Last resolution status code */
 enum {
-	RSLV_STATUS_NONE = 0,  /* no resolution occured yet */
+	RSLV_STATUS_NONE = 0,  /* no resolution occurred yet */
 	RSLV_STATUS_VALID,     /* no error */
 	RSLV_STATUS_INVALID,   /* invalid responses */
 	RSLV_STATUS_ERROR,     /* error */

--- a/include/types/fd.h
+++ b/include/types/fd.h
@@ -81,7 +81,7 @@ enum fd_states {
 /* This is the value used to mark a file descriptor as dead. This value is
  * negative, this is important so that tests on fd < 0 properly match. It
  * also has the nice property of being highly negative but not overflowing
- * nor changing sign on 32-bit machines when multipled by sizeof(fdtab).
+ * nor changing sign on 32-bit machines when multiplied by sizeof(fdtab).
  * This ensures that any unexpected dereference of such an uninitialized
  * file descriptor will lead to so large a dereference that it will crash
  * the process at the exact location of the bug with a clean stack trace

--- a/include/types/filters.h
+++ b/include/types/filters.h
@@ -251,8 +251,8 @@ struct strm_flt {
 	                                       * If NULL, we start from the first filter.
 	                                       * 0: request channel, 1: response channel */
 	unsigned short flags;                 /* STRM_FL_* */
-	unsigned char  nb_req_data_filters;   /* Number of data filters registerd on the request channel */
-	unsigned char  nb_rsp_data_filters;   /* Number of data filters registerd on the response channel */
+	unsigned char  nb_req_data_filters;   /* Number of data filters registered on the request channel */
+	unsigned char  nb_rsp_data_filters;   /* Number of data filters registered on the response channel */
 };
 
 #endif /* _TYPES_FILTERS_H */

--- a/include/types/listener.h
+++ b/include/types/listener.h
@@ -87,7 +87,7 @@ enum li_state {
 /* listener socket options */
 #define LI_O_NONE               0x0000
 #define LI_O_NOLINGER           0x0001  /* disable linger on this socket */
-#define LI_O_FOREIGN            0x0002  /* permit listening on foreing addresses ("transparent") */
+#define LI_O_FOREIGN            0x0002  /* permit listening on foreign addresses ("transparent") */
 #define LI_O_NOQUICKACK         0x0004  /* disable quick ack of immediate data (linux) */
 #define LI_O_DEF_ACCEPT         0x0008  /* wait up to 1 second for data before accepting */
 #define LI_O_TCP_L4_RULES       0x0010  /* run TCP L4 rules checks on the incoming connection */

--- a/include/types/proto_http.h
+++ b/include/types/proto_http.h
@@ -187,11 +187,11 @@ enum {
 	STAT_STATUS_INIT = 0,
 	STAT_STATUS_DENY,	/* action denied */
 	STAT_STATUS_DONE,	/* the action is successful */
-	STAT_STATUS_ERRP,	/* an error occured due to invalid values in parameters */
-	STAT_STATUS_EXCD,	/* an error occured because the buffer couldn't store all data */
+	STAT_STATUS_ERRP,	/* an error occurred due to invalid values in parameters */
+	STAT_STATUS_EXCD,	/* an error occurred because the buffer couldn't store all data */
 	STAT_STATUS_NONE,	/* nothing happened (no action chosen or servers state didn't change) */
 	STAT_STATUS_PART,	/* the action is partially successful */
-	STAT_STATUS_UNKN,	/* an unknown error occured, shouldn't happen */
+	STAT_STATUS_UNKN,	/* an unknown error occurred, shouldn't happen */
 	STAT_STATUS_SIZE
 };
 
@@ -207,7 +207,7 @@ enum {
  *                             During parsing, it points to last header seen
  *                             for states after START. When in HTTP_MSG_BODY,
  *                             eoh points to the first byte of the last CRLF
- *                             preceeding data. Relative to buffer's origin.
+ *                             preceding data. Relative to buffer's origin.
  *                             This value then remains unchanged till the end
  *                             so that we can rewind the buffer to change some
  *                             headers if needed (eg: http-send-name-header).

--- a/include/types/proxy.h
+++ b/include/types/proxy.h
@@ -121,7 +121,7 @@ enum PR_SRV_STATE_FILE {
 #define PR_O_HTTP_MODE  0x07000000      /* MASK to retrieve the HTTP mode */
 
 #define PR_O_TCPCHK_SSL 0x08000000	/* at least one TCPCHECK connect rule requires SSL */
-#define PR_O_CONTSTATS	0x10000000	/* continous counters */
+#define PR_O_CONTSTATS	0x10000000	/* continuous counters */
 #define PR_O_HTTP_PROXY 0x20000000	/* Enable stream to use HTTP proxy operations */
 #define PR_O_DISABLE404 0x40000000      /* Disable a server on a 404 response to a health-check */
 #define PR_O_ORGTO      0x80000000      /* insert x-original-to with destination address */

--- a/include/types/server.h
+++ b/include/types/server.h
@@ -272,7 +272,7 @@ struct server {
 	struct dns_resolvers *resolvers;	/* pointer to the resolvers structure used by this server */
 	char *lastaddr;				/* the address string provided by the server-state file */
 	struct dns_options dns_opts;
-	int hostname_dn_len;			/* sting lenght of the server hostname in Domain Name format */
+	int hostname_dn_len;			/* sting length of the server hostname in Domain Name format */
 	char *hostname_dn;			/* server hostname in Domain Name format */
 	char *hostname;				/* server hostname */
 	struct sockaddr_storage init_addr;	/* plain IP address specified on the init-addr line */
@@ -322,7 +322,7 @@ struct server {
 		short status, code;
 		char reason[128];
 	} op_st_chg;				/* operational status change's reason */
-	char adm_st_chg_cause[48];		/* adminstrative status change's cause */
+	char adm_st_chg_cause[48];		/* administrative status change's cause */
 };
 
 /* Descriptor for a "server" keyword. The ->parse() function returns 0 in case of

--- a/reg-tests/log/b00000.vtc
+++ b/reg-tests/log/b00000.vtc
@@ -8,7 +8,7 @@
 # requiring LW_BYTES is set), the log is emitted after the connection is
 # closed, so the address and ports cannot be retrieved anymore.
 #
-# It could be argued that we'd make a special case of these to immediatly
+# It could be argued that we'd make a special case of these to immediately
 # retrieve the source and destination addresses from the connection, but it
 # seems cleaner to simply pin the front connection, marking it "tracked" by
 # adding the LW_XPRT flag to mention that we'll need some of these elements

--- a/reg-tests/lua/b00002.lua
+++ b/reg-tests/lua/b00002.lua
@@ -106,7 +106,7 @@ core.Info("4")
 		repeat
 			local d = socket:receive(res.contentlength)
 			if d == nil then
---				core.Info("luacurl, ERROR?: recieved NIL, expecting "..res.contentlength.." bytes only got "..string.len(res.body).." sofar")
+--				core.Info("luacurl, ERROR?: received NIL, expecting "..res.contentlength.." bytes only got "..string.len(res.body).." sofar")
 				return
 			else
 				res.body = res.body..d
@@ -116,7 +116,7 @@ core.Info("4")
 					break
 				end
 			end
---			core.Info("processhttpresponse, Loopy, get more body data! to recieve complete contentlenght")
+--			core.Info("processhttpresponse, Loopy, get more body data! to receive complete contentlenght")
 		until false
 	end
 	if res.headers["Transfer-Encoding"] ~= nil and res.headers["Transfer-Encoding"] == "chunked" then

--- a/src/51d.c
+++ b/src/51d.c
@@ -378,7 +378,7 @@ static int _51d_fetch(const struct arg *args, struct sample *smp, const char *kw
 	struct lru64 *lru = NULL;
 #endif
 
-	/* Needed to ensure that the HTTP message has been fully recieved when
+	/* Needed to ensure that the HTTP message has been fully received when
 	 * used with TCP operation. Not required for HTTP operation.
 	 * Data type has to be reset to ensure the string output is processed
 	 * correctly.

--- a/src/acl.c
+++ b/src/acl.c
@@ -188,7 +188,7 @@ struct acl_expr *parse_acl_expr(const char **args, char **err, struct arg_list *
 		smp->fetch = aclkw->smp;
 		smp->arg_p = empty_arg_list;
 
-		/* look for the begining of the subject arguments */
+		/* look for the beginning of the subject arguments */
 		for (arg = args[0]; *arg && *arg != '(' && *arg != ','; arg++);
 
 		endt = arg;
@@ -230,7 +230,7 @@ struct acl_expr *parse_acl_expr(const char **args, char **err, struct arg_list *
 		}
 		arg = endt;
 
-		/* look for the begining of the converters list. Those directly attached
+		/* look for the beginning of the converters list. Those directly attached
 		 * to the ACL keyword are found just after <arg> which points to the comma.
 		 * If we find any converter, then we don't use the ACL keyword's match
 		 * anymore but the one related to the converter's output type.

--- a/src/base64.c
+++ b/src/base64.c
@@ -99,7 +99,7 @@ int base64dec(const char *in, size_t ilen, char *out, size_t olen) {
 		if (b < 0)
 			return -1;
 
-		/* padding has to be continous */
+		/* padding has to be continuous */
 		if (pad && b != B64PADV)
 			return -1;
 

--- a/src/cache.c
+++ b/src/cache.c
@@ -218,7 +218,7 @@ cache_store_http_forward_data(struct stream *s, struct filter *filter,
 		return len;
 
 	if (!len) {
-		/* Nothing to foward */
+		/* Nothing to forward */
 		ret = len;
 	}
 	else if (st->hdrs_len >= len) {
@@ -565,7 +565,7 @@ static void http_cache_applet_release(struct appctx *appctx)
 
 /*
  * Append an "Age" header into <chn> channel for this <ce> cache entry.
- * This is the responsability of the caller to insure there is enough
+ * This is the responsibility of the caller to insure there is enough
  * data in the channel.
  *
  * Returns the number of bytes inserted if succeeded, 0 if failed.
@@ -642,7 +642,7 @@ static void http_cache_io_handler(struct appctx *appctx)
 	if (unlikely(si->state == SI_ST_DIS || si->state == SI_ST_CLO))
 		goto out;
 
-	/* Check if the input buffer is avalaible. */
+	/* Check if the input buffer is available. */
 	if (res->buf.size == 0) {
 		si_applet_cant_put(si);
 		goto out;

--- a/src/cfgparse.c
+++ b/src/cfgparse.c
@@ -7122,7 +7122,7 @@ next_line:
 			line++;
 
 
-		if (*line == '[') {/* This is the begining if a scope */
+		if (*line == '[') {/* This is the beginning if a scope */
 			err_code |= cfg_parse_scope(file, linenum, line);
 			goto next_line;
 		}
@@ -8517,7 +8517,7 @@ out_uri_auth_compat:
 
 		}
 		/* We have to initialize the server lookup mechanism depending
-		 * on what LB algorithm was choosen.
+		 * on what LB algorithm was chosen.
 		 */
 
 		curproxy->lbprm.algo &= ~(BE_LB_LKUP | BE_LB_PROP_DYN);

--- a/src/cli.c
+++ b/src/cli.c
@@ -548,7 +548,7 @@ static void cli_io_handler(struct appctx *appctx)
 	if (unlikely(si->state == SI_ST_DIS || si->state == SI_ST_CLO))
 		goto out;
 
-	/* Check if the input buffer is avalaible. */
+	/* Check if the input buffer is available. */
 	if (res->buf.size == 0) {
 		si_applet_cant_put(si);
 		goto out;
@@ -2051,7 +2051,7 @@ int pcli_wait_for_response(struct stream *s, struct channel *rep, int an_bit)
 
 		/* We must trim any excess data from the response buffer, because we
 		 * may have blocked an invalid response from a server that we don't
-		 * want to accidentely forward once we disable the analysers, nor do
+		 * want to accidently forward once we disable the analysers, nor do
 		 * we want those data to come along with next response. A typical
 		 * example of such data would be from a buggy server responding to
 		 * a HEAD with some data, or sending more than the advertised

--- a/src/dns.c
+++ b/src/dns.c
@@ -974,14 +974,14 @@ int dns_get_ip_from_response(struct dns_response_packet *dns_p,
 	max_score         = -1;
 
 	/* Select an IP regarding configuration preference.
-	 * Top priority is the prefered network ip version,
-	 * second priority is the prefered network.
+	 * Top priority is the preferred network ip version,
+	 * second priority is the preferred network.
 	 * the last priority is the currently used IP,
 	 *
 	 * For these three priorities, a score is calculated. The
 	 * weight are:
-	 *  8 - prefered ip version.
-	 *  4 - prefered network.
+	 *  8 - preferred ip version.
+	 *  4 - preferred network.
 	 *  2 - if the ip in the record is not affected to any other server in the same backend (duplication)
 	 *  1 - current ip.
 	 * The result with the biggest score is returned.
@@ -1003,11 +1003,11 @@ int dns_get_ip_from_response(struct dns_response_packet *dns_p,
 			continue;
 		score = 0;
 
-		/* Check for prefered ip protocol. */
+		/* Check for preferred ip protocol. */
 		if (ip_type == family_priority)
 			score += 8;
 
-		/* Check for prefered network. */
+		/* Check for preferred network. */
 		for (j = 0; j < dns_opts->pref_net_nb; j++) {
 
 			/* Compare only the same adresses class. */

--- a/src/filters.c
+++ b/src/filters.c
@@ -299,8 +299,8 @@ flt_init_all()
 	return 0;
 }
 
-/* Calls flt_init_per_thread() for all proxies, see above.  Be carefull here, it
- * returns 0 if an error occured. This is the opposite of flt_init_all. */
+/* Calls flt_init_per_thread() for all proxies, see above.  Be careful here, it
+ * returns 0 if an error occurred. This is the opposite of flt_init_all. */
 static int
 flt_init_all_per_thread()
 {
@@ -550,7 +550,7 @@ flt_http_data(struct stream *s, struct http_msg *msg)
 
 		/* If the HTTP parser is ahead, we update the next offset of the
 		 * current filter. This happens for chunked messages, at the
-		 * begining of a new chunk. */
+		 * beginning of a new chunk. */
 		nxt = &FLT_NXT(filter, msg->chn);
 		if (msg->next > *nxt)
 			*nxt = msg->next;
@@ -914,7 +914,7 @@ flt_end_analyze(struct stream *s, struct channel *chn, unsigned int an_bit)
 		 * one will remain. This is a way to be sure that
 		 * 'channel_end_analyze' callback will have a chance to be
 		 * called at least once for the other side to finish the current
-		 * processing. Of course, this is the filter responsiblity to
+		 * processing. Of course, this is the filter responsibility to
 		 * wakeup the stream if it choose to loop on this callback. */
 		s->req.flags |= CF_WAKE_ONCE;
 		s->res.flags |= CF_WAKE_ONCE;

--- a/src/flt_http_comp.c
+++ b/src/flt_http_comp.c
@@ -269,7 +269,7 @@ comp_http_forward_data(struct stream *s, struct filter *filter,
 
 	if (!st->initialized) {
 		if (!len) {
-			/* Nothing to foward */
+			/* Nothing to forward */
 			ret = len;
 		}
 		else if (st->hdrs_len > len) {
@@ -715,7 +715,7 @@ http_compression_buffer_end(struct comp_state *st, struct stream *s,
 	 * (chunk size, trailers, ...).
 	 */
 
-	/* Write real size at the begining of the chunk, no need of wrapping.
+	/* Write real size at the beginning of the chunk, no need of wrapping.
 	 * We write the chunk using a dynamic length and adjust out->p and out->i
 	 * accordingly afterwards. That will move <out> away from <data>.
 	 */

--- a/src/flt_spoe.c
+++ b/src/flt_spoe.c
@@ -383,7 +383,7 @@ spoe_str_to_vsn(const char *str, size_t len)
 }
 
 /* Encode the HELLO frame sent by HAProxy to an agent. It returns the number of
- * encoded bytes in the frame on success, 0 if an encoding error occured and -1
+ * encoded bytes in the frame on success, 0 if an encoding error occurred and -1
  * if a fatal error occurred. */
 static int
 spoe_prepare_hahello_frame(struct appctx *appctx, char *frame, size_t size)
@@ -2179,14 +2179,14 @@ spoe_encode_message(struct stream *s, struct spoe_context *ctx,
 		if (ctx->frag_ctx.curoff != UINT_MAX)
 			goto encode_arg_value;
 
-		/* Encode the arguement name as a string. It can by NULL */
+		/* Encode the argument name as a string. It can by NULL */
 		if (spoe_encode_buffer(arg->name, arg->name_len, buf, end) == -1)
 			goto too_big;
 
 		ctx->frag_ctx.curoff = 0;
 	  encode_arg_value:
 
-		/* Fetch the arguement value */
+		/* Fetch the argument value */
 		smp = sample_process(s->be, s->sess, s, dir|SMP_OPT_FINAL, arg->expr, NULL);
 		ret = spoe_encode_data(smp, &ctx->frag_ctx.curoff, buf, end);
 		if (ret == -1 || ctx->frag_ctx.curoff)
@@ -3974,7 +3974,7 @@ cfg_parse_spoe_message(const char *file, int linenum, char **args, int kwm)
 		else if (!strcmp(args[1], spoe_event_str[SPOE_EV_ON_HTTP_RSP]))
 			curmsg->event = SPOE_EV_ON_HTTP_RSP;
 		else {
-			ha_alert("parsing [%s:%d] : unkown event '%s'.\n",
+			ha_alert("parsing [%s:%d] : unknown event '%s'.\n",
 				 file, linenum, args[1]);
 			err_code |= ERR_ALERT | ERR_FATAL;
 			goto out;

--- a/src/haproxy.c
+++ b/src/haproxy.c
@@ -688,7 +688,7 @@ static void get_cur_unixsocket()
 
 /*
  * When called, this function reexec haproxy with -sf followed by current
- * children PIDs and possibily old children PIDs if they didn't leave yet.
+ * children PIDs and possibility old children PIDs if they didn't leave yet.
  */
 static void mworker_reload()
 {
@@ -758,13 +758,13 @@ static void mworker_reload()
 	return;
 
 alloc_error:
-	ha_warning("Failed to reexecute the master processs [%d]: Cannot allocate memory\n", pid);
+	ha_warning("Failed to reexecute the master processes [%d]: Cannot allocate memory\n", pid);
 	return;
 }
 
 /*
  * When called, this function reexec haproxy with -sf followed by current
- * children PIDs and possibily old children PIDs if they didn't leave yet.
+ * children PIDs and possibility old children PIDs if they didn't leave yet.
  */
 static void mworker_catch_sighup(struct sig_handler *sh)
 {
@@ -1044,8 +1044,8 @@ static void stdio_quiet(int fd)
 }
 
 
-/* This function check if cfg_cfgfiles containes directories.
- * If it find one, it add all the files (and only files) it containes
+/* This function check if cfg_cfgfiles contains directories.
+ * If it find one, it add all the files (and only files) it contains
  * in cfg_cfgfiles in place of the directory (and remove the directory).
  * It add the files in lexical order.
  * It add only files with .cfg extension.
@@ -1089,7 +1089,7 @@ static void cfgfiles_expand_directories(void)
 			char *d_name_cfgext = strstr(dir_entry->d_name, ".cfg");
 
 			/* don't add filename that begin with .
-			 * only add filename with .cfg extention
+			 * only add filename with .cfg extension
 			 */
 			if (dir_entry->d_name[0] == '.' ||
 			    !(d_name_cfgext && d_name_cfgext[4] == '\0'))
@@ -1683,7 +1683,7 @@ static void init(int argc, char **argv)
 		exit(1);
 	}
 
-	/* handle cfgfiles that are actualy directories */
+	/* handle cfgfiles that are actually directories */
 	cfgfiles_expand_directories();
 
 	if (LIST_ISEMPTY(&cfg_cfgfiles))

--- a/src/hlua.c
+++ b/src/hlua.c
@@ -241,7 +241,7 @@ static const char error_500[] =
 	"Connection: close\r\n"
 	"Content-Type: text/html\r\n"
 	"\r\n"
-	"<html><body><h1>500 Internal Server Error</h1>\nAn internal server error occured.\n</body></html>\n";
+	"<html><body><h1>500 Internal Server Error</h1>\nAn internal server error occurred.\n</body></html>\n";
 
 /* These functions converts types between HAProxy internal args or
  * sample and LUA types. Another function permits to check if the
@@ -584,7 +584,7 @@ static int hlua_lua2smp(lua_State *L, int ud, struct sample *smp)
 }
 
 /* This function check the "argp" builded by another conversion function
- * is in accord with the expected argp defined by the "mask". The fucntion
+ * is in accord with the expected argp defined by the "mask". The function
  * returns true or false. It can be adjust the types if there compatibles.
  *
  * This function assumes thant the argp argument contains ARGM_NBARGS + 1
@@ -884,7 +884,7 @@ __LJMP void hlua_yieldk(lua_State *L, int nresults, int ctx,
  * This function manipulates two Lua stack: the main and the thread. Only
  * the main stack can fail. The thread is not manipulated. This function
  * MUST NOT manipulate the created thread stack state, because is not
- * proctected agains error throwed by the thread stack.
+ * proctected against error throwed by the thread stack.
  */
 int hlua_ctx_init(struct hlua *lua, struct task *task)
 {
@@ -1048,11 +1048,11 @@ void hlua_hook(lua_State *L, lua_Debug *ar)
  *  - HLUA_E_OK     : The execution is terminated without any errors.
  *  - HLUA_E_AGAIN  : The execution must continue at the next associated
  *                    task wakeup.
- *  - HLUA_E_ERRMSG : An error has occured, an error message is set in
+ *  - HLUA_E_ERRMSG : An error has occurred, an error message is set in
  *                    the top of the stack.
- *  - HLUA_E_ERR    : An error has occured without error message.
+ *  - HLUA_E_ERR    : An error has occurred without error message.
  *
- * If an error occured, the stack is renewed and it is ready to run new
+ * If an error occurred, the stack is renewed and it is ready to run new
  * LUA code.
  */
 static enum hlua_exec hlua_ctx_resume(struct hlua *lua, int yield_allowed)
@@ -1126,7 +1126,7 @@ resume_execution:
 
 	case LUA_ERRRUN:
 
-		/* Special exit case. The traditionnal exit is returned as an error
+		/* Special exit case. The traditional exit is returned as an error
 		 * because the errors ares the only one mean to return immediately
 		 * from and lua execution.
 		 */
@@ -1573,7 +1573,7 @@ __LJMP static struct hlua_socket *hlua_checksocket(lua_State *L, int ud)
 }
 
 /* This function is the handler called for each I/O on the established
- * connection. It is used for notify space avalaible to send or data
+ * connection. It is used for notify space available to send or data
  * received.
  */
 static void hlua_socket_handler(struct appctx *appctx)
@@ -1590,7 +1590,7 @@ static void hlua_socket_handler(struct appctx *appctx)
 		stream_shutdown(si_strm(si), SF_ERR_KILLED);
 	}
 
-	/* If the connection object is not avalaible, close all the
+	/* If the connection object is not available, close all the
 	 * streams and wakeup everithing waiting for.
 	 */
 	if (!c) {
@@ -1622,7 +1622,7 @@ static void hlua_socket_handler(struct appctx *appctx)
 	/* This function is called after the connect. */
 	appctx->ctx.hlua_cosocket.connected = 1;
 
-	/* Wake the tasks which wants to write if the buffer have avalaible space. */
+	/* Wake the tasks which wants to write if the buffer have available space. */
 	if (channel_may_recv(si_ic(si)))
 		notification_wake(&appctx->ctx.hlua_cosocket.wake_on_write);
 
@@ -1784,7 +1784,7 @@ __LJMP static int hlua_socket_receive_yield(struct lua_State *L, int status, lua
 		nblk = co_getline_nc(oc, &blk1, &len1, &blk2, &len2);
 		if (nblk < 0) /* Connection close. */
 			goto connection_closed;
-		if (nblk == 0) /* No data avalaible. */
+		if (nblk == 0) /* No data available. */
 			goto connection_empty;
 
 		/* remove final \r\n. */
@@ -1815,7 +1815,7 @@ __LJMP static int hlua_socket_receive_yield(struct lua_State *L, int status, lua
 		nblk = co_getblk_nc(oc, &blk1, &len1, &blk2, &len2);
 		if (nblk < 0) /* Connection close. */
 			goto connection_closed;
-		if (nblk == 0) /* No data avalaible. */
+		if (nblk == 0) /* No data available. */
 			goto connection_empty;
 	}
 
@@ -1824,7 +1824,7 @@ __LJMP static int hlua_socket_receive_yield(struct lua_State *L, int status, lua
 		nblk = co_getblk_nc(oc, &blk1, &len1, &blk2, &len2);
 		if (nblk < 0) /* Connection close. */
 			goto connection_closed;
-		if (nblk == 0) /* No data avalaible. */
+		if (nblk == 0) /* No data available. */
 			goto connection_empty;
 
 		missing_bytes = wanted - socket->b.n;
@@ -2026,7 +2026,7 @@ static int hlua_socket_write_yield(struct lua_State *L,int status, lua_KContext 
 		return 1; /* Implicitly return the length sent. */
 	}
 
-	/* Check if the buffer is avalaible because HAProxy doesn't allocate
+	/* Check if the buffer is available because HAProxy doesn't allocate
 	 * the request buffer if its not required.
 	 */
 	if (s->req.buf.size == 0) {
@@ -2034,7 +2034,7 @@ static int hlua_socket_write_yield(struct lua_State *L,int status, lua_KContext 
 			goto hlua_socket_write_yield_return;
 	}
 
-	/* Check for avalaible space. */
+	/* Check for available space. */
 	len = b_room(&s->req.buf);
 	if (len <= 0) {
 		goto hlua_socket_write_yield_return;
@@ -2684,7 +2684,7 @@ __LJMP static int hlua_socket_new(lua_State *L)
  */
 
 /* The state between the channel data and the HTTP parser state can be
- * unconsistent, so reset the parser and call it again. Warning, this
+ * inconsistent, so reset the parser and call it again. Warning, this
  * action not revalidate the request and not send a 400 if the modified
  * resuest is not valid.
  *
@@ -2866,7 +2866,7 @@ __LJMP static int hlua_channel_get_yield(lua_State *L, int status, lua_KContext 
 	return 1;
 }
 
-/* Check arguments for the fucntion "hlua_channel_get_yield". */
+/* Check arguments for the function "hlua_channel_get_yield". */
 __LJMP static int hlua_channel_get(lua_State *L)
 {
 	MAY_LJMP(check_args(L, 1, "get"));
@@ -2876,7 +2876,7 @@ __LJMP static int hlua_channel_get(lua_State *L)
 
 /* This functions consumes and returns one line. If the channel is closed,
  * and the last data does not contains a final '\n', the data are returned
- * without the final '\n'. When no more data are avalaible, it returns nil
+ * without the final '\n'. When no more data are available, it returns nil
  * value.
  */
 __LJMP static int hlua_channel_getline_yield(lua_State *L, int status, lua_KContext ctx)
@@ -2914,7 +2914,7 @@ __LJMP static int hlua_channel_getline_yield(lua_State *L, int status, lua_KCont
 	return 1;
 }
 
-/* Check arguments for the fucntion "hlua_channel_getline_yield". */
+/* Check arguments for the function "hlua_channel_getline_yield". */
 __LJMP static int hlua_channel_getline(lua_State *L)
 {
 	MAY_LJMP(check_args(L, 1, "getline"));
@@ -2938,7 +2938,7 @@ __LJMP static int hlua_channel_append_yield(lua_State *L, int status, lua_KConte
 	int ret;
 	int max;
 
-	/* Check if the buffer is avalaible because HAProxy doesn't allocate
+	/* Check if the buffer is available because HAProxy doesn't allocate
 	 * the request buffer if its not required.
 	 */
 	if (chn->buf.size == 0) {
@@ -2966,7 +2966,7 @@ __LJMP static int hlua_channel_append_yield(lua_State *L, int status, lua_KConte
 
 	max = channel_recv_limit(chn) - b_data(&chn->buf);
 	if (max == 0 && co_data(chn) == 0) {
-		/* There are no space avalaible, and the output buffer is empty.
+		/* There are no space available, and the output buffer is empty.
 		 * in this case, we cannot add more data, so we cannot yield,
 		 * we return the amount of copyied data.
 		 */
@@ -3013,8 +3013,8 @@ __LJMP static int hlua_channel_set(lua_State *L)
 	return MAY_LJMP(hlua_channel_append_yield(L, 0, 0));
 }
 
-/* Append data in the output side of the buffer. This data is immediatly
- * sent. The fcuntion returns the ammount of data writed. If the buffer
+/* Append data in the output side of the buffer. This data is immediately
+ * sent. The fcuntion returns the amount of data writed. If the buffer
  * cannot contains the data, the function yield. The function returns -1
  * if the channel is closed.
  */
@@ -3032,7 +3032,7 @@ __LJMP static int hlua_channel_send_yield(lua_State *L, int status, lua_KContext
 		return 1;
 	}
 
-	/* Check if the buffer is avalaible because HAProxy doesn't allocate
+	/* Check if the buffer is available because HAProxy doesn't allocate
 	 * the request buffer if its not required.
 	 */
 	if (chn->buf.size == 0) {
@@ -3040,14 +3040,14 @@ __LJMP static int hlua_channel_send_yield(lua_State *L, int status, lua_KContext
 		MAY_LJMP(hlua_yieldk(L, 0, 0, hlua_channel_send_yield, TICK_ETERNITY, 0));
 	}
 
-	/* the writed data will be immediatly sent, so we can check
-	 * the avalaible space without taking in account the reserve.
-	 * The reserve is guaranted for the processing of incoming
+	/* the writed data will be immediately sent, so we can check
+	 * the available space without taking in account the reserve.
+	 * The reserve is guaranteed for the processing of incoming
 	 * data, because the buffer will be flushed.
 	 */
 	max = b_room(&chn->buf);
 
-	/* If there are no space avalaible, and the output buffer is empty.
+	/* If there are no space available, and the output buffer is empty.
 	 * in this case, we cannot add more data, so we cannot yield,
 	 * we return the amount of copyied data.
 	 */
@@ -3058,7 +3058,7 @@ __LJMP static int hlua_channel_send_yield(lua_State *L, int status, lua_KContext
 	if (max > len - l)
 		max = len - l;
 
-	/* The buffer avalaible size may be not contiguous. This test
+	/* The buffer available size may be not contiguous. This test
 	 * detects a non contiguous buffer and realign it.
 	 */
 	if (ci_space_for_replace(chn) < max)
@@ -3076,7 +3076,7 @@ __LJMP static int hlua_channel_send_yield(lua_State *L, int status, lua_KContext
 	lua_pop(L, 1);
 	lua_pushinteger(L, l);
 
-	/* If there are no space avalaible, and the output buffer is empty.
+	/* If there are no space available, and the output buffer is empty.
 	 * in this case, we cannot add more data, so we cannot yield,
 	 * we return the amount of copyied data.
 	 */
@@ -3282,7 +3282,7 @@ __LJMP static int hlua_run_sample_fetch(lua_State *L)
 	/* Get closure arguments. */
 	f = lua_touserdata(L, lua_upvalueindex(1));
 
-	/* Get traditionnal arguments. */
+	/* Get traditional arguments. */
 	hsmp = MAY_LJMP(hlua_checkfetches(L, 1));
 
 	/* Check execution authorization. */
@@ -3396,7 +3396,7 @@ __LJMP static int hlua_run_sample_conv(lua_State *L)
 	/* Get closure arguments. */
 	conv = lua_touserdata(L, lua_upvalueindex(1));
 
-	/* Get traditionnal arguments. */
+	/* Get traditional arguments. */
 	hsmp = MAY_LJMP(hlua_checkconverters(L, 1));
 
 	/* Get extra arguments. */
@@ -3657,10 +3657,10 @@ __LJMP static int hlua_applet_tcp_getline_yield(lua_State *L, int status, lua_KC
 	const char *blk2;
 	size_t len2;
 
-	/* Read the maximum amount of data avalaible. */
+	/* Read the maximum amount of data available. */
 	ret = co_getline_nc(si_oc(si), &blk1, &len1, &blk2, &len2);
 
-	/* Data not yet avalaible. return yield. */
+	/* Data not yet available. return yield. */
 	if (ret == 0) {
 		si_applet_cant_get(si);
 		MAY_LJMP(hlua_yieldk(L, 0, 0, hlua_applet_tcp_getline_yield, TICK_ETERNITY, 0));
@@ -3686,7 +3686,7 @@ __LJMP static int hlua_applet_tcp_getline_yield(lua_State *L, int status, lua_KC
 	return 1;
 }
 
-/* Check arguments for the fucntion "hlua_channel_get_yield". */
+/* Check arguments for the function "hlua_channel_get_yield". */
 __LJMP static int hlua_applet_tcp_getline(lua_State *L)
 {
 	struct hlua_appctx *appctx = MAY_LJMP(hlua_checkapplet_tcp(L, 1));
@@ -3712,10 +3712,10 @@ __LJMP static int hlua_applet_tcp_recv_yield(lua_State *L, int status, lua_KCont
 	const char *blk2;
 	size_t len2;
 
-	/* Read the maximum amount of data avalaible. */
+	/* Read the maximum amount of data available. */
 	ret = co_getblk_nc(si_oc(si), &blk1, &len1, &blk2, &len2);
 
-	/* Data not yet avalaible. return yield. */
+	/* Data not yet available. return yield. */
 	if (ret == 0) {
 		si_applet_cant_get(si);
 		MAY_LJMP(hlua_yieldk(L, 0, 0, hlua_applet_tcp_recv_yield, TICK_ETERNITY, 0));
@@ -3760,7 +3760,7 @@ __LJMP static int hlua_applet_tcp_recv_yield(lua_State *L, int status, lua_KCont
 		/* Consume input channel output buffer data. */
 		co_skip(si_oc(si), len1 + len2);
 
-		/* If we are no other data avalaible, yield waiting for new data. */
+		/* If we are no other data available, yield waiting for new data. */
 		if (len > 0) {
 			lua_pushinteger(L, len);
 			lua_replace(L, 2);
@@ -3779,7 +3779,7 @@ __LJMP static int hlua_applet_tcp_recv_yield(lua_State *L, int status, lua_KCont
 	return 0;
 }
 
-/* Check arguments for the fucntion "hlua_channel_get_yield". */
+/* Check arguments for the function "hlua_channel_get_yield". */
 __LJMP static int hlua_applet_tcp_recv(lua_State *L)
 {
 	struct hlua_appctx *appctx = MAY_LJMP(hlua_checkapplet_tcp(L, 1));
@@ -3801,8 +3801,8 @@ __LJMP static int hlua_applet_tcp_recv(lua_State *L)
 	return MAY_LJMP(hlua_applet_tcp_recv_yield(L, 0, 0));
 }
 
-/* Append data in the output side of the buffer. This data is immediatly
- * sent. The fcuntion returns the ammount of data writed. If the buffer
+/* Append data in the output side of the buffer. This data is immediately
+ * sent. The fcuntion returns the amount of data writed. If the buffer
  * cannot contains the data, the function yield. The function returns -1
  * if the channel is closed.
  */
@@ -4142,10 +4142,10 @@ __LJMP static int hlua_applet_http_getline_yield(lua_State *L, int status, lua_K
 		return 1;
 	}
 
-	/* Read the maximum amount of data avalaible. */
+	/* Read the maximum amount of data available. */
 	ret = co_getline_nc(si_oc(si), &blk1, &len1, &blk2, &len2);
 
-	/* Data not yet avalaible. return yield. */
+	/* Data not yet available. return yield. */
 	if (ret == 0) {
 		si_applet_cant_get(si);
 		MAY_LJMP(hlua_yieldk(L, 0, 0, hlua_applet_http_getline_yield, TICK_ETERNITY, 0));
@@ -4179,7 +4179,7 @@ __LJMP static int hlua_applet_http_getline_yield(lua_State *L, int status, lua_K
 	return 1;
 }
 
-/* Check arguments for the fucntion "hlua_channel_get_yield". */
+/* Check arguments for the function "hlua_channel_get_yield". */
 __LJMP static int hlua_applet_http_getline(lua_State *L)
 {
 	struct hlua_appctx *appctx = MAY_LJMP(hlua_checkapplet_http(L, 1));
@@ -4222,10 +4222,10 @@ __LJMP static int hlua_applet_http_recv_yield(lua_State *L, int status, lua_KCon
 		appctx->appctx->ctx.hlua_apphttp.flags &= ~APPLET_100C;
 	}
 
-	/* Read the maximum amount of data avalaible. */
+	/* Read the maximum amount of data available. */
 	ret = co_getblk_nc(si_oc(si), &blk1, &len1, &blk2, &len2);
 
-	/* Data not yet avalaible. return yield. */
+	/* Data not yet available. return yield. */
 	if (ret == 0) {
 		si_applet_cant_get(si);
 		MAY_LJMP(hlua_yieldk(L, 0, 0, hlua_applet_http_recv_yield, TICK_ETERNITY, 0));
@@ -4258,7 +4258,7 @@ __LJMP static int hlua_applet_http_recv_yield(lua_State *L, int status, lua_KCon
 	if (appctx->appctx->ctx.hlua_apphttp.left_bytes != -1)
 		appctx->appctx->ctx.hlua_apphttp.left_bytes -= len;
 
-	/* If we are no other data avalaible, yield waiting for new data. */
+	/* If we are no other data available, yield waiting for new data. */
 	if (len > 0) {
 		lua_pushinteger(L, len);
 		lua_replace(L, 2);
@@ -4271,7 +4271,7 @@ __LJMP static int hlua_applet_http_recv_yield(lua_State *L, int status, lua_KCon
 	return 1;
 }
 
-/* Check arguments for the fucntion "hlua_channel_get_yield". */
+/* Check arguments for the function "hlua_channel_get_yield". */
 __LJMP static int hlua_applet_http_recv(lua_State *L)
 {
 	struct hlua_appctx *appctx = MAY_LJMP(hlua_checkapplet_http(L, 1));
@@ -4296,8 +4296,8 @@ __LJMP static int hlua_applet_http_recv(lua_State *L)
 	return MAY_LJMP(hlua_applet_http_recv_yield(L, 0, 0));
 }
 
-/* Append data in the output side of the buffer. This data is immediatly
- * sent. The fcuntion returns the ammount of data writed. If the buffer
+/* Append data in the output side of the buffer. This data is immediately
+ * sent. The fcuntion returns the amount of data writed. If the buffer
  * cannot contains the data, the function yield. The function returns -1
  * if the channel is closed.
  */
@@ -4855,7 +4855,7 @@ __LJMP static int hlua_http_res_rep_val(lua_State *L)
 	return MAY_LJMP(hlua_http_rep_hdr(L, htxn, &htxn->s->txn->rsp, ACT_HTTP_REPLACE_VAL));
 }
 
-/* This function deletes all the occurences of an header.
+/* This function deletes all the occurrences of an header.
  * It is a wrapper for the 2 following functions.
  */
 __LJMP static inline int hlua_http_del_hdr(lua_State *L, struct hlua_txn *htxn, struct http_msg *msg)
@@ -5208,7 +5208,7 @@ static int hlua_txn_new(lua_State *L, struct stream *s, struct proxy *p, int dir
 
 	/* NOTE: The allocation never fails. The failure
 	 * throw an error, and the function never returns.
-	 * if the throw is not avalaible, the process is aborted.
+	 * if the throw is not available, the process is aborted.
 	 */
 	/* Create the object: obj[0] = userdata. */
 	lua_newtable(L);
@@ -5616,7 +5616,7 @@ __LJMP static int hlua_set_nice(lua_State *L)
 	return 0;
 }
 
-/* This function is used as a calback of a task. It is called by the
+/* This function is used as a callback of a task. It is called by the
  * HAProxy task subsystem when the task is awaked. The LUA runtime can
  * return an E_AGAIN signal, the emmiter of this signal must set a
  * signal to wake the task.
@@ -6081,7 +6081,7 @@ __LJMP static int hlua_register_converters(lua_State *L)
 	return 0;
 }
 
-/* This fucntion is an LUA binding used for registering
+/* This function is an LUA binding used for registering
  * "sample-fetch" functions. It expects a converter name used
  * in the haproxy configuration file, and an LUA function.
  */
@@ -6261,7 +6261,7 @@ static enum act_return hlua_action(struct act_rule *rule, struct proxy *px,
 		}
 		/* Some actions can be wake up when a "write" event
 		 * is detected on a response channel. This is useful
-		 * only for actions targetted on the requests.
+		 * only for actions targeted on the requests.
 		 */
 		if (HLUA_IS_WAKERESWR(s->hlua)) {
 			s->res.flags |= CF_WAKE_WRITE;
@@ -6696,7 +6696,7 @@ static void hlua_applet_http_fct(struct appctx *ctx)
 		 * for the Lua.
 		 */
 
-		/* Read the maximum amount of data avalaible. */
+		/* Read the maximum amount of data available. */
 		ret = co_getblk_nc(si_oc(si), &blk1, &len1, &blk2, &len2);
 		if (ret == -1)
 			return;
@@ -6808,7 +6808,7 @@ error:
 
 	/* If we are in HTTP mode, and we are not send any
 	 * data, return a 500 server error in best effort:
-	 * if there are no room avalaible in the buffer,
+	 * if there are no room available in the buffer,
 	 * just close the connection.
 	 */
 	ci_putblk(res, error_500, strlen(error_500));
@@ -6947,7 +6947,7 @@ __LJMP static int hlua_register_action(lua_State *L)
 	/* Third argument : lua function. */
 	ref = MAY_LJMP(hlua_checkfunction(L, 3));
 
-	/* Fouth argument : number of mandatories arguments expected on the configuration line. */
+	/* Fourth argument : number of mandatories arguments expected on the configuration line. */
 	if (lua_gettop(L) >= 4)
 		nargs = MAY_LJMP(luaL_checkinteger(L, 4));
 
@@ -7438,8 +7438,8 @@ static int hlua_parse_maxmem(char **args, int section_type, struct proxy *curpx,
  * execute an lua file during the parsing of the HAProxy configuration file. It is
  * the main lua entry point.
  *
- * This funtion runs with the HAProxy keywords API. It returns -1 if an error is
- * occured, otherwise it returns 0.
+ * This function runs with the HAProxy keywords API. It returns -1 if an error is
+ * occurred, otherwise it returns 0.
  *
  * In some error case, LUA set an error message in top of the stack. This function
  * returns this error message in the HAProxy logs and pop it from the stack.
@@ -7638,7 +7638,7 @@ void hlua_init(void)
 	gL.Tref = LUA_REFNIL;
 	gL.task = NULL;
 
-	/* From this point, until the end of the initialisation fucntion,
+	/* From this point, until the end of the initialisation function,
 	 * the Lua function can fail with an abort. We are in the initialisation
 	 * process of HAProxy, this abort() is tolerated.
 	 */
@@ -8145,7 +8145,7 @@ void hlua_init(void)
 			/*
 			 *
 			 * If the keyword is not known, we can search in the registered
-			 * server keywords. This is usefull to configure special SSL
+			 * server keywords. This is useful to configure special SSL
 			 * features like client certificates and ssl_verify.
 			 *
 			 */

--- a/src/hlua_fcn.c
+++ b/src/hlua_fcn.c
@@ -90,7 +90,7 @@ static int hlua_fcn_pushunsigned_ll(lua_State *L, unsigned long long val) {
 int hlua_fcn_pushfield(lua_State *L, struct field *field)
 {
 	/* The lua_Integer is always signed. Its length depends on
-	 * compilation opions, so the followinfg code is conditionned
+	 * compilation opions, so the followinfg code is conditioned
 	 * by some macros. Windows maros are not supported.
 	 * If the number cannot be represented as integer, we try to
 	 * convert to float.
@@ -205,7 +205,7 @@ void hlua_class_function(lua_State *L, const char *name, int (*function)(lua_Sta
 	lua_rawset(L, -3);
 }
 
-/* This function returns a string containg the HAProxy object name. */
+/* This function returns a string containing the HAProxy object name. */
 int hlua_dump_object(struct lua_State *L)
 {
 	const char *name = (const char *)lua_tostring(L, lua_upvalueindex(1));

--- a/src/http.c
+++ b/src/http.c
@@ -299,7 +299,7 @@ static const char *http_err_msgs[HTTP_ERR_SIZE] = {
 	"Connection: close\r\n"
 	"Content-Type: text/html\r\n"
 	"\r\n"
-	"<html><body><h1>500 Internal Server Error</h1>\nAn internal server error occured.\n</body></html>\n",
+	"<html><body><h1>500 Internal Server Error</h1>\nAn internal server error occurred.\n</body></html>\n",
 
 	[HTTP_ERR_502] =
 	"HTTP/1.0 502 Bad Gateway\r\n"
@@ -446,7 +446,7 @@ const char *http_get_reason(unsigned int status)
 	case 503: return "Service Unavailable";
 	case 504: return "Gateway Time-out";
 	case 505: return "HTTP Version not supported";
-	case 506: return "Variant also negociate";
+	case 506: return "Variant also negotiate";
 	case 507: return "Insufficient storage";
 	case 508: return "Loop detected";
 	case 509: return "Bandwidth Limit Exceeded";
@@ -697,7 +697,7 @@ char *http_extract_cookie_value(char *hdr, const char *hdr_end,
 	return NULL;
 }
 
-/* Parses a qvalue and returns it multipled by 1000, from 0 to 1000. If the
+/* Parses a qvalue and returns it multiplied by 1000, from 0 to 1000. If the
  * value is larger than 1000, it is bound to 1000. The parser consumes up to
  * 1 digit, one dot and 3 digits and stops on the first invalid character.
  * Unparsable qvalues return 1000 as "q=1.000".
@@ -733,7 +733,7 @@ int http_parse_qvalue(const char *qvalue, const char **end)
 }
 
 /*
- * Given a url parameter, find the starting position of the first occurence,
+ * Given a url parameter, find the starting position of the first occurrence,
  * or NULL if the parameter is not found.
  *
  * Example: if query_string is "yo=mama;ye=daddy" and url_param_name is "ye",

--- a/src/http_conv.c
+++ b/src/http_conv.c
@@ -218,7 +218,7 @@ static int sample_conv_url_dec(const struct arg *args, struct sample *smp, void 
 {
 	int len;
 
-	/* If the constant flag is set or if not size is avalaible at
+	/* If the constant flag is set or if not size is available at
 	 * the end of the buffer, copy the string in other buffer
 	  * before decoding.
 	 */

--- a/src/http_fetch.c
+++ b/src/http_fetch.c
@@ -355,7 +355,7 @@ static int smp_fetch_uniqueid(const struct arg *args, struct sample *smp, const 
 }
 
 /* Returns a string block containing all headers including the
- * empty line wich separes headers from the body. This is useful
+ * empty line which separes headers from the body. This is useful
  * form some headers analysis.
  */
 static int smp_fetch_hdrs(const struct arg *args, struct sample *smp, const char *kw, void *private)

--- a/src/lb_fwrr.c
+++ b/src/lb_fwrr.c
@@ -586,7 +586,7 @@ struct server *fwrr_get_next_server(struct proxy *p, struct server *srvtoavoid)
 
  requeue_servers:
 	/* Requeue all extracted servers. If full==srv then it was
-	 * avoided (unsucessfully) and chained, omit it now.
+	 * avoided (unsuccessfully) and chained, omit it now.
 	 */
 	if (unlikely(full != NULL)) {
 		if (switched) {

--- a/src/log.c
+++ b/src/log.c
@@ -559,7 +559,7 @@ int parse_logformat_string(const char *fmt, struct proxy *curproxy, struct list 
 		if (!*str)
 			cformat = LF_END;              // preset it to save all states from doing this
 
-		/* The prinicple of the two-step state machine below is to first detect a change, and
+		/* The principle of the two-step state machine below is to first detect a change, and
 		 * second have all common paths processed at one place. The common paths are the ones
 		 * encountered in text areas (LF_INIT, LF_TEXT, LF_SEPARATOR) and at the end (LF_END).
 		 * We use the common LF_INIT state to dispatch to the different final states.
@@ -1054,7 +1054,7 @@ static char *lf_encode_chunk(char *start, char *stop,
  * Write a string in the log string
  * Take cares of quote and escape options
  *
- * Return the adress of the \0 character, or NULL on error
+ * Return the address of the \0 character, or NULL on error
  */
 char *lf_text_len(char *dst, const char *src, size_t len, size_t size, const struct logformat_node *node)
 {
@@ -1106,7 +1106,7 @@ static inline char *lf_text(char *dst, const char *src, size_t size, const struc
 }
 
 /*
- * Write a IP adress to the log string
+ * Write a IP address to the log string
  * +X option write in hexadecimal notation, most signifant byte on the left
  */
 char *lf_ip(char *dst, const struct sockaddr *sockaddr, size_t size, const struct logformat_node *node)
@@ -1574,7 +1574,7 @@ void init_log()
 	 *
 	 * All the chars are encoded except "VCHAR", "obs-text", SP and HTAB.
 	 * The encoded chars are form 0x00 to 0x08, 0x0a to 0x1f and 0x7f. The
-	 * "obs-fold" is volontary forgotten because haproxy remove this.
+	 * "obs-fold" is voluntary forgotten because haproxy remove this.
 	 */
 	memset(http_encode_map, 0, sizeof(http_encode_map));
 	for (i = 0x00; i <= 0x08; i++)

--- a/src/map.c
+++ b/src/map.c
@@ -225,7 +225,7 @@ static int sample_conv_map(const struct arg *arg_p, struct sample *smp, void *pr
 		return 1;
 	}
 
-	/* If no default value avalaible, the converter fails. */
+	/* If no default value available, the converter fails. */
 	if (arg_p[1].type == ARGT_STOP)
 		return 0;
 
@@ -404,7 +404,7 @@ static int cli_io_handler_pats_list(struct appctx *appctx)
 	switch (appctx->st2) {
 	case STAT_ST_INIT:
 		/* Display the column headers. If the message cannot be sent,
-		 * quit the fucntion with returning 0. The function is called
+		 * quit the function with returning 0. The function is called
 		 * later and restart at the state "STAT_ST_INIT".
 		 */
 		chunk_reset(&trash);

--- a/src/mux_h2.c
+++ b/src/mux_h2.c
@@ -645,7 +645,7 @@ static void h2s_destroy(struct h2s *h2s)
 		h2s->send_wait->wait_reason &= ~SUB_CAN_SEND;
 	if (h2s->recv_wait != NULL)
 		h2s->recv_wait->wait_reason &= ~SUB_CAN_RECV;
-	/* There's no need to explicitely call unsubscribe here, the only
+	/* There's no need to explicitly call unsubscribe here, the only
 	 * reference left would be in the h2c send_list/fctl_list, and if
 	 * we're in it, we're getting out anyway
 	 */
@@ -1002,7 +1002,7 @@ static int h2s_send_rst_stream(struct h2c *h2c, struct h2s *h2s)
  *
  * Returns > 0 on success or zero if nothing was done. In case of lack of room
  * to write the message, it blocks the demuxer and subscribes it to future
- * notifications. It's worth mentionning that an RST may even be sent for a
+ * notifications. It's worth mentioning that an RST may even be sent for a
  * closed stream.
  */
 static int h2c_send_rst_stream(struct h2c *h2c, struct h2s *h2s)

--- a/src/pattern.c
+++ b/src/pattern.c
@@ -425,8 +425,8 @@ int pat_parse_ip(const char *text, struct pattern *pattern, int mflags, char **e
  *
  * These functions are exported and may be used by any other component.
  *
- * This fucntion just take a sample <smp> and check if this sample match
- * with the pattern <pattern>. This fucntion return just PAT_MATCH or
+ * This function just take a sample <smp> and check if this sample match
+ * with the pattern <pattern>. This function return just PAT_MATCH or
  * PAT_NOMATCH.
  *
  */
@@ -1671,7 +1671,7 @@ int pat_ref_delete_by_id(struct pat_ref *ref, struct pat_ref_elt *refelt)
 }
 
 /* This function remove all pattern match <key> from the the reference
- * and from each expr member of the reference. This fucntion returns 1
+ * and from each expr member of the reference. This function returns 1
  * if the deletion is done and return 0 is the entry is not found.
  */
 int pat_ref_delete(struct pat_ref *ref, const char *key)
@@ -1840,7 +1840,7 @@ int pat_ref_set(struct pat_ref *ref, const char *key, const char *value, char **
 /* This function create new reference. <ref> is the reference name.
  * <flags> are PAT_REF_*. /!\ The reference is not checked, and must
  * be unique. The user must check the reference with "pat_ref_lookup()"
- * before calling this function. If the fucntion fail, it return NULL,
+ * before calling this function. If the function fail, it return NULL,
  * else return new struct pat_ref.
  */
 struct pat_ref *pat_ref_new(const char *reference, const char *display, unsigned int flags)
@@ -2200,7 +2200,7 @@ struct pattern_expr *pattern_lookup_expr(struct pattern_head *head, struct pat_r
 }
 
 /* This function create new pattern_expr associated to the reference <ref>.
- * <ref> can be NULL. If an error is occured, the function returns NULL and
+ * <ref> can be NULL. If an error is occurred, the function returns NULL and
  * <err> is filled. Otherwise, the function returns new pattern_expr linked
  * with <head> and <ref>.
  *

--- a/src/peers.c
+++ b/src/peers.c
@@ -263,7 +263,7 @@ static inline void peer_set_update_msg_type(char *msg_type, int use_identifier, 
 /*
  * This prepare the data update message on the stick session <ts>, <st> is the considered
  * stick table.
- *  <msg> is a buffer of <size> to recieve data message content
+ *  <msg> is a buffer of <size> to receive data message content
  * If function returns 0, the caller should consider we were unable to encode this message (TODO:
  * check size)
  */
@@ -375,7 +375,7 @@ static int peer_prepare_updatemsg(struct stksess *ts, struct shared_table *st, u
 
 /*
  * This prepare the switch table message to targeted share table <st>.
- *  <msg> is a buffer of <size> to recieve data message content
+ *  <msg> is a buffer of <size> to receive data message content
  * If function returns 0, the caller should consider we were unable to encode this message (TODO:
  * check size)
  */
@@ -457,7 +457,7 @@ static int peer_prepare_switchmsg(struct shared_table *st, char *msg, size_t siz
 /*
  * This prepare the acknowledge message on the stick session <ts>, <st> is the considered
  * stick table.
- *  <msg> is a buffer of <size> to recieve data message content
+ *  <msg> is a buffer of <size> to receive data message content
  * If function returns 0, the caller should consider we were unable to encode this message (TODO:
  * check size)
  */
@@ -571,7 +571,7 @@ static void peer_io_handler(struct appctx *appctx)
 	size_t proto_len = strlen(PEER_SESSION_PROTO_NAME);
 	unsigned int maj_ver, min_ver;
 
-	/* Check if the input buffer is avalaible. */
+	/* Check if the input buffer is available. */
 	if (si_ic(si)->buf.size == 0)
 		goto full;
 
@@ -2119,7 +2119,7 @@ static struct task *process_peer_sync(struct task * task, void *context, unsigne
 	else {
 		/* soft stop case */
 		if (task->state & TASK_WOKEN_SIGNAL) {
-			/* We've just recieved the signal */
+			/* We've just received the signal */
 			if (!(peers->flags & PEERS_F_DONOTSTOP)) {
 				/* add DO NOT STOP flag if not present */
 				HA_ATOMIC_ADD(&jobs, 1);

--- a/src/proto_http.c
+++ b/src/proto_http.c
@@ -1199,7 +1199,7 @@ int http_wait_for_request(struct stream *s, struct channel *req, int an_bit)
 			}
 		}
 
-		/* nothing to fail, let's reply normaly */
+		/* nothing to fail, let's reply normally */
 		txn->status = 200;
 		http_reply_and_close(s, txn->status, http_error_message(s));
 		if (!(s->flags & SF_ERR_MASK))
@@ -2068,7 +2068,7 @@ resume_execution:
 			}
 			break;
 
-		/* other flags exists, but normaly, they never be matched. */
+		/* other flags exists, but normally, they never be matched. */
 		default:
 			break;
 		}
@@ -2414,7 +2414,7 @@ resume_execution:
 			}
 			break;
 
-		/* other flags exists, but normaly, they never be matched. */
+		/* other flags exists, but normally, they never be matched. */
 		default:
 			break;
 		}
@@ -6414,7 +6414,7 @@ void manage_client_side_cookies(struct stream *s, struct channel *req)
 				 * - delete the complete cookie if we're in insert+indirect mode, so that
 				 *   the server never sees it ;
 				 * - remove the server id from the cookie value, and tag the cookie as an
-				 *   application cookie so that it does not get accidentely removed later,
+				 *   application cookie so that it does not get accidently removed later,
 				 *   if we're in cookie prefix mode
 				 */
 				if ((s->be->ck_opts & PR_CK_PFX) && (delim != val_end)) {
@@ -7599,7 +7599,7 @@ void http_reset_txn(struct stream *s)
 
 	/* We must trim any excess data from the response buffer, because we
 	 * may have blocked an invalid response from a server that we don't
-	 * want to accidentely forward once we disable the analysers, nor do
+	 * want to accidently forward once we disable the analysers, nor do
 	 * we want those data to come along with next response. A typical
 	 * example of such data would be from a buggy server responding to
 	 * a HEAD with some data, or sending more than the advertised

--- a/src/proto_sockpair.c
+++ b/src/proto_sockpair.c
@@ -336,7 +336,7 @@ static int sockpair_connect_server(struct connection *conn, int data, int delack
 
 
 /*
- * Receive a file descriptor transfered from a unix socket.
+ * Receive a file descriptor transferred from a unix socket.
  *
  * Return -1 or a socket fd;
  *

--- a/src/proto_tcp.c
+++ b/src/proto_tcp.c
@@ -1534,7 +1534,7 @@ smp_fetch_dport(const struct arg *args, struct sample *smp, const char *kw, void
 
 #ifdef TCP_INFO
 
-/* Returns some tcp_info data is its avalaible. "dir" must be set to 0 if
+/* Returns some tcp_info data is its available. "dir" must be set to 0 if
  * the client connection is require, otherwise it is set to 1. "val" represents
  * the required value. Use 0 for rtt and 1 for rttavg. "unit" is the expected unit
  * by default, the rtt is in us. Id "unit" is set to 0, the unit is us, if it is

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -358,13 +358,13 @@ static int proxy_parse_declare(char **args, int section, struct proxy *curpx,
 {
 	/* Capture keyword wannot be declared in a default proxy. */
 	if (curpx == defpx) {
-		memprintf(err, "'%s' not avalaible in default section", args[0]);
+		memprintf(err, "'%s' not available in default section", args[0]);
 		return -1;
 	}
 
-	/* Capture keywork is only avalaible in frontend. */
+	/* Capture keywork is only available in frontend. */
 	if (!(curpx->cap & PR_CAP_FE)) {
-		memprintf(err, "'%s' only avalaible in frontend or listen section", args[0]);
+		memprintf(err, "'%s' only available in frontend or listen section", args[0]);
 		return -1;
 	}
 
@@ -374,9 +374,9 @@ static int proxy_parse_declare(char **args, int section, struct proxy *curpx,
 		return -1;
 	}
 
-	/* Actually, declare is only avalaible for declaring capture
+	/* Actually, declare is only available for declaring capture
 	 * slot, but in the future it can declare maps or variables.
-	 * So, this section permits to check and switch acording with
+	 * So, this section permits to check and switch according with
 	 * the second keyword.
 	 */
 	if (strcmp(args[1], "capture") == 0) {
@@ -570,7 +570,7 @@ struct proxy *proxy_find_best_match(int cap, const char *name, int id, int *diff
 			return byname;
 	}
 
-	/* remaining possiblities :
+	/* remaining possibilities :
 	 *   - name not set
 	 *   - name set but not found
 	 *   - name found, but ID doesn't match.
@@ -594,7 +594,7 @@ struct proxy *proxy_find_best_match(int cap, const char *name, int id, int *diff
 				}
 			}
 
-			/* remaining possiblities :
+			/* remaining possibilities :
 			 *   - name not set
 			 *   - name set but not found
 			 */
@@ -611,7 +611,7 @@ struct proxy *proxy_find_best_match(int cap, const char *name, int id, int *diff
 		}
 	}
 
-	/* All remaining possiblities will lead to NULL. If we can report more
+	/* All remaining possibilities will lead to NULL. If we can report more
 	 * detailed information to the caller about changed types and/or name,
 	 * we'll do it. For example, we could detect that "listen foo" was
 	 * split into "frontend foo_ft" and "backend foo_bk" if IDs are forced.
@@ -944,7 +944,7 @@ struct task *hard_stop(struct task *t, void *context, unsigned short state)
 	if (killed) {
 		ha_warning("Some tasks resisted to hard-stop, exiting now.\n");
 		send_log(NULL, LOG_WARNING, "Some tasks resisted to hard-stop, exiting now.\n");
-		/* Do some cleanup and explicitely quit */
+		/* Do some cleanup and explicitly quit */
 		deinit();
 		exit(0);
 	}
@@ -1333,7 +1333,7 @@ int stream_set_backend(struct stream *s, struct proxy *be)
  * are passed :
  *  - <proxy> is the proxy where the error was detected and where the snapshot
  *    needs to be stored
- *  - <is_back> indicates that the error happend when receiving the response
+ *  - <is_back> indicates that the error happened when receiving the response
  *  - <other_end> is a pointer to the proxy on the other side when known
  *  - <target> is the target of the connection, usually a server or a proxy
  *  - <sess> is the session which experienced the error

--- a/src/queue.c
+++ b/src/queue.c
@@ -343,7 +343,7 @@ void process_srv_queue(struct server *s)
  * The offset can be positive or negative, and an offset of 0 puts it in the
  * middle of this range (~ 8 min). Note that this also means if the adjusted
  * timestamp wraps around, the request will be misinterpreted as being of
- * the higest priority for that priority class.
+ * the highest priority for that priority class.
  *
  * This function must be called by the stream itself, so in the context of
  * process_stream.

--- a/src/regex.c
+++ b/src/regex.c
@@ -193,7 +193,7 @@ int regex_exec_match(const struct my_regex *preg, const char *subject,
 	 * value from a successful match is 1, indicating that just the first pair of
 	 * offsets has been set.
 	 *
-	 * It seems that this function returns 0 if it detect more matches than avalaible
+	 * It seems that this function returns 0 if it detect more matches than available
 	 * space in the matches array.
 	 */
 #ifdef USE_PCRE2
@@ -286,7 +286,7 @@ int regex_exec_match2(const struct my_regex *preg, char *subject, int length,
 	 * value from a successful match is 1, indicating that just the first pair of
 	 * offsets has been set.
 	 *
-	 * It seems that this function returns 0 if it detect more matches than avalaible
+	 * It seems that this function returns 0 if it detect more matches than available
 	 * space in the matches array.
 	 */
 #ifdef USE_PCRE2

--- a/src/sample.c
+++ b/src/sample.c
@@ -639,7 +639,7 @@ static int c_int2str(struct sample *smp)
 	return 1;
 }
 
-/* This function inconditionally duplicates data and removes the "const" flag.
+/* This function unconditionally duplicates data and removes the "const" flag.
  * For strings and binary blocks, it also provides a known allocated size with
  * a length that is capped to the size, and ensures a trailing zero is always
  * appended for strings. This is necessary for some operations which may
@@ -2354,7 +2354,7 @@ static int sample_conv_binary_cpl(const struct arg *arg_p, struct sample *smp, v
 }
 
 /* Takes a SINT on input, applies a binary "and" with the SINT directly in
- * arg_p or in the varaible described in arg_p, and returns the SINT result.
+ * arg_p or in the variable described in arg_p, and returns the SINT result.
  */
 static int sample_conv_binary_and(const struct arg *arg_p, struct sample *smp, void *private)
 {
@@ -2368,7 +2368,7 @@ static int sample_conv_binary_and(const struct arg *arg_p, struct sample *smp, v
 }
 
 /* Takes a SINT on input, applies a binary "or" with the SINT directly in
- * arg_p or in the varaible described in arg_p, and returns the SINT result.
+ * arg_p or in the variable described in arg_p, and returns the SINT result.
  */
 static int sample_conv_binary_or(const struct arg *arg_p, struct sample *smp, void *private)
 {
@@ -2382,7 +2382,7 @@ static int sample_conv_binary_or(const struct arg *arg_p, struct sample *smp, vo
 }
 
 /* Takes a SINT on input, applies a binary "xor" with the SINT directly in
- * arg_p or in the varaible described in arg_p, and returns the SINT result.
+ * arg_p or in the variable described in arg_p, and returns the SINT result.
  */
 static int sample_conv_binary_xor(const struct arg *arg_p, struct sample *smp, void *private)
 {
@@ -2422,7 +2422,7 @@ static inline long long int arith_add(long long int a, long long int b)
 }
 
 /* Takes a SINT on input, applies an arithmetic "add" with the SINT directly in
- * arg_p or in the varaible described in arg_p, and returns the SINT result.
+ * arg_p or in the variable described in arg_p, and returns the SINT result.
  */
 static int sample_conv_arith_add(const struct arg *arg_p, struct sample *smp, void *private)
 {
@@ -2436,7 +2436,7 @@ static int sample_conv_arith_add(const struct arg *arg_p, struct sample *smp, vo
 }
 
 /* Takes a SINT on input, applies an arithmetic "sub" with the SINT directly in
- * arg_p or in the varaible described in arg_p, and returns the SINT result.
+ * arg_p or in the variable described in arg_p, and returns the SINT result.
  */
 static int sample_conv_arith_sub(const struct arg *arg_p,
                                  struct sample *smp, void *private)
@@ -2458,7 +2458,7 @@ static int sample_conv_arith_sub(const struct arg *arg_p,
 		return 1;
 	}
 
-	/* standard substraction: we use the "add" function and negate
+	/* standard subtraction: we use the "add" function and negate
 	 * the second operand.
 	 */
 	smp->data.u.sint = arith_add(smp->data.u.sint, -tmp.data.u.sint);
@@ -2466,7 +2466,7 @@ static int sample_conv_arith_sub(const struct arg *arg_p,
 }
 
 /* Takes a SINT on input, applies an arithmetic "mul" with the SINT directly in
- * arg_p or in the varaible described in arg_p, and returns the SINT result.
+ * arg_p or in the variable described in arg_p, and returns the SINT result.
  * If the result makes an overflow, then the largest possible quantity is
  * returned.
  */
@@ -2511,7 +2511,7 @@ static int sample_conv_arith_mul(const struct arg *arg_p,
 }
 
 /* Takes a SINT on input, applies an arithmetic "div" with the SINT directly in
- * arg_p or in the varaible described in arg_p, and returns the SINT result.
+ * arg_p or in the variable described in arg_p, and returns the SINT result.
  * If arg_p makes the result overflow, then the largest possible quantity is
  * returned.
  */
@@ -2540,7 +2540,7 @@ static int sample_conv_arith_div(const struct arg *arg_p,
 }
 
 /* Takes a SINT on input, applies an arithmetic "mod" with the SINT directly in
- * arg_p or in the varaible described in arg_p, and returns the SINT result.
+ * arg_p or in the variable described in arg_p, and returns the SINT result.
  * If arg_p makes the result overflow, then 0 is returned.
  */
 static int sample_conv_arith_mod(const struct arg *arg_p,

--- a/src/server.c
+++ b/src/server.c
@@ -1921,7 +1921,7 @@ static inline void srv_set_id_from_prefix(struct server *srv, const char *prefix
  * Note that a server template is a special server with
  * a few different parameters than a server which has
  * been parsed mostly the same way as a server.
- * Returns the number of servers succesfully allocated,
+ * Returns the number of servers successfully allocated,
  * 'srv' template included.
  */
 static int server_template_init(struct server *srv, struct proxy *px)
@@ -2303,7 +2303,7 @@ int parse_server(const char *file, int linenum, char **args, struct proxy *curpr
 				p = args[cur_arg + 1];
 				e = p;
 				while (*p != '\0') {
-					/* If no room avalaible, return error. */
+					/* If no room available, return error. */
 					if (opt->pref_net_nb >= SRV_MAX_PREF_NET) {
 						ha_alert("parsing [%s:%d]: '%s' exceed %d networks.\n",
 						      file, linenum, args[cur_arg], SRV_MAX_PREF_NET);
@@ -3043,7 +3043,7 @@ static void srv_update_state(struct server *srv, int version, char **params)
 					 * - reload for any other reason than a FQDN modification,
 					 * the configuration file FQDN matches the fqdn server state file value.
 					 * So we must reset the 'set from stats socket FQDN' flag to be consistent with
-					 * any futher FQDN modification.
+					 * any further FQDN modification.
 					 */
 					srv->next_admin &= ~SRV_ADMF_HMAINT;
 				}

--- a/src/session.c
+++ b/src/session.c
@@ -75,7 +75,7 @@ void session_free(struct session *sess)
 }
 
 /* callback used from the connection/mux layer to notify that a connection is
- * gonig to be released.
+ * going to be released.
  */
 void conn_session_free(struct connection *conn)
 {

--- a/src/shctx.c
+++ b/src/shctx.c
@@ -243,7 +243,7 @@ int shctx_row_data_append(struct shared_context *shctx,
 
 /*
  * Copy <len> data from a row of blocks, return the remaining data to copy
- * If 0 is returned, the full data has successfuly be copied
+ * If 0 is returned, the full data has successfully be copied
  *
  * The row should be in the hot list
  */

--- a/src/signal.c
+++ b/src/signal.c
@@ -134,7 +134,7 @@ void haproxy_unblock_signals()
 	sigset_t set;
 
 	/* Ensure signals are not blocked. Some shells or service managers may
-	 * accidently block all of our signals unfortunately, causing lots of
+	 * accidentally block all of our signals unfortunately, causing lots of
 	 * zombie processes to remain in the background during reloads.
 	 */
 	sigemptyset(&set);

--- a/src/ssl_sock.c
+++ b/src/ssl_sock.c
@@ -1053,7 +1053,7 @@ int ssl_sock_ocsp_stapling_cbk(SSL *ssl, void *arg)
  * is displayed).
  *
  * Returns 1 if no ".ocsp" file found, 0 if OCSP status extension is
- * succesfully enabled, or -1 in other error case.
+ * successfully enabled, or -1 in other error case.
  */
 static int ssl_sock_load_ocsp(SSL_CTX *ctx, const char *cert_path)
 {
@@ -1500,7 +1500,7 @@ void ssl_sock_parse_clienthello(int write_p, int version, int content_type,
 
 	/* This function is called for "from client" and "to server"
 	 * connections. The combination of write_p == 0 and content_type == 22
-	 * is only avalaible during "from client" connection.
+	 * is only available during "from client" connection.
 	 */
 
 	/* "write_p" is set to 0 is the bytes are received messages,
@@ -2634,7 +2634,7 @@ int ssl_sock_load_global_dh_param_from_file(const char *filename)
 }
 
 /* Loads Diffie-Hellman parameter from a file. Returns 1 if loaded, else -1
-   if an error occured, and 0 if parameter not found. */
+   if an error occurred, and 0 if parameter not found. */
 int ssl_sock_load_dh_params(SSL_CTX *ctx, const char *file)
 {
 	int ret = -1;
@@ -2978,7 +2978,7 @@ static void ssl_sock_populate_sni_keytypes_hplr(const char *str, struct eb_root 
  * If any are found, group these files into a set of SSL_CTX*
  * based on shared and unique CN and SAN entries. Add these SSL_CTX* to the SNI tree.
  *
- * This will allow the user to explictly group multiple cert/keys for a single purpose
+ * This will allow the user to explicitly group multiple cert/keys for a single purpose
  *
  * Returns
  *     0 on success
@@ -3086,7 +3086,7 @@ static int ssl_sock_load_multi_cert(const char *path, struct bind_conf *bind_con
 	 * and add each CTX to the SNI tree
 	 *
 	 * Some math here:
-	 *   There are 2^n - 1 possibile combinations, each unique
+	 *   There are 2^n - 1 possible combinations, each unique
 	 *   combination is denoted by the key in the map. Each key
 	 *   has a value between 1 and 2^n - 1. Conveniently, the array
 	 *   of SSL_CTX* is sized 2^n. So, we can simply use the i'th
@@ -3801,7 +3801,7 @@ ssl_sock_initial_ctx(struct bind_conf *bind_conf)
 
 #if (OPENSSL_VERSION_NUMBER < 0x1010000fL)
 	/* Keep force-xxx implementation as it is in older haproxy. It's a
-	   precautionary measure to avoid any suprise with older openssl version. */
+	   precautionary measure to avoid any surprise with older openssl version. */
 	if (min == max)
 		methodVersions[min].ctx_set_version(ctx, SET_SERVER);
 	else
@@ -4585,7 +4585,7 @@ int ssl_sock_prepare_srv_ctx(struct server *srv)
 
 #if (OPENSSL_VERSION_NUMBER < 0x1010000fL)
 	/* Keep force-xxx implementation as it is in older haproxy. It's a
-	   precautionary measure to avoid any suprise with older openssl version. */
+	   precautionary measure to avoid any surprise with older openssl version. */
 	if (min == max)
 		methodVersions[min].ctx_set_version(ctx, SET_CLIENT);
 	else
@@ -5875,7 +5875,7 @@ ssl_sock_get_serial(X509 *crt, struct buffer *out)
 }
 
 /* Extract a cert to der, and copy it to a chunk.
- * Returns 1 if cert is found and copied, 0 on der convertion failure and
+ * Returns 1 if cert is found and copied, 0 on der conversion failure and
  * -1 if output is not large enough.
  */
 static int
@@ -8560,7 +8560,7 @@ static int cli_io_handler_tlskeys_files(struct appctx *appctx) {
 	switch (appctx->st2) {
 	case STAT_ST_INIT:
 		/* Display the column headers. If the message cannot be sent,
-		 * quit the fucntion with returning 0. The function is called
+		 * quit the function with returning 0. The function is called
 		 * later and restart at the state "STAT_ST_INIT".
 		 */
 		chunk_reset(&trash);

--- a/src/standard.c
+++ b/src/standard.c
@@ -2103,7 +2103,7 @@ const char *parse_time_err(const char *text, unsigned *ret, unsigned unit_flags)
 
 /* this function converts the string starting at <text> to an unsigned int
  * stored in <ret>. If an error is detected, the pointer to the unexpected
- * character is returned. If the conversio is succesful, NULL is returned.
+ * character is returned. If the conversio is successful, NULL is returned.
  */
 const char *parse_size_err(const char *text, unsigned *ret) {
 	unsigned value = 0;
@@ -2186,7 +2186,7 @@ int parse_binary(const char *source, char **binstr, int *binstrlen, char **err)
 	}
 	else {
 		if (*binstrlen < len) {
-			memprintf(err, "no space avalaible in the buffer. expect %d, provides %d",
+			memprintf(err, "no space available in the buffer. expect %d, provides %d",
 			          len, *binstrlen);
 			return 0;
 		}
@@ -2682,7 +2682,7 @@ const char rfc4291_pfx[] = { 0x00, 0x00, 0x00, 0x00,
 			     0x00, 0x00, 0x00, 0x00,
 			     0x00, 0x00, 0xFF, 0xFF };
 
-/* Map IPv4 adress on IPv6 address, as specified in RFC 3513.
+/* Map IPv4 address on IPv6 address, as specified in RFC 3513.
  * Input and output may overlap.
  */
 void v4tov6(struct in6_addr *sin6_addr, struct in_addr *sin_addr)
@@ -2694,7 +2694,7 @@ void v4tov6(struct in6_addr *sin6_addr, struct in_addr *sin_addr)
 	memcpy(sin6_addr->s6_addr+12, &tmp_addr.s_addr, 4);
 }
 
-/* Map IPv6 adress on IPv4 address, as specified in RFC 3513.
+/* Map IPv6 address on IPv4 address, as specified in RFC 3513.
  * Return true if conversion is possible and false otherwise.
  */
 int v6tov4(struct in_addr *sin_addr, struct in6_addr *sin6_addr)

--- a/src/stats.c
+++ b/src/stats.c
@@ -3040,7 +3040,7 @@ static void http_stats_io_handler(struct appctx *appctx)
 	if (unlikely(si->state == SI_ST_DIS || si->state == SI_ST_CLO))
 		goto out;
 
-	/* Check if the input buffer is avalaible. */
+	/* Check if the input buffer is available. */
 	if (res->buf.size == 0) {
 		si_applet_cant_put(si);
 		goto out;

--- a/src/stick_table.c
+++ b/src/stick_table.c
@@ -1923,7 +1923,7 @@ smp_fetch_sc_stkctr(struct session *sess, struct stream *strm, const struct arg 
 		if (!conn)
 			return NULL;
 
-		/* Fetch source adress in a sample. */
+		/* Fetch source address in a sample. */
 		smp.px = NULL;
 		smp.sess = sess;
 		smp.strm = strm;
@@ -1985,7 +1985,7 @@ smp_create_src_stkctr(struct session *sess, struct stream *strm, const struct ar
 	if (!conn)
 		return NULL;
 
-	/* Fetch source adress in a sample. */
+	/* Fetch source address in a sample. */
 	smp.px = NULL;
 	smp.sess = sess;
 	smp.strm = strm;
@@ -2520,7 +2520,7 @@ smp_fetch_src_updt_conn_cnt(const struct arg *args, struct sample *smp, const ch
 	if (!conn)
 		return 0;
 
-	/* Fetch source adress in a sample. */
+	/* Fetch source address in a sample. */
 	if (!smp_fetch_src(NULL, smp, NULL, NULL))
 		return 0;
 

--- a/src/stream.c
+++ b/src/stream.c
@@ -87,7 +87,7 @@ int stream_create_from_cs(struct conn_stream *cs)
 
 /* This function is called from the session handler which detects the end of
  * handshake, in order to complete initialization of a valid stream. It must be
- * called with a completley initialized session. It returns the pointer to
+ * called with a completely initialized session. It returns the pointer to
  * the newly created stream, or NULL in case of fatal error. The client-facing
  * end point is assigned to <origin>, which must be valid. The stream's task
  * is configured with a nice value inherited from the listener's nice if any.

--- a/src/task.c
+++ b/src/task.c
@@ -429,7 +429,7 @@ void process_runnable_tasks()
 		}
 		curr_task = NULL;
 		/* If there is a pending state  we have to wake up the task
-		 * immediatly, else we defer it into wait queue
+		 * immediately, else we defer it into wait queue
 		 */
 		if (t != NULL) {
 			state = HA_ATOMIC_AND(&t->state, ~TASK_RUNNING);

--- a/src/vars.c
+++ b/src/vars.c
@@ -59,7 +59,7 @@ static void var_accounting_diff(struct vars *vars, struct session *sess, struct 
 }
 
 /* This function returns 1 if the <size> is available in the var
- * pool <vars>, otherwise returns 0. If the space is avalaible,
+ * pool <vars>, otherwise returns 0. If the space is available,
  * the size is reserved. The inner pointers may be null when setting
  * the outer ones only. The accounting uses either <sess> or <strm>
  * depending on the scope. <strm> may be NULL when no stream is known
@@ -110,7 +110,7 @@ unsigned int var_clear(struct var *var)
 	return size;
 }
 
-/* This function free all the memory used by all the varaibles
+/* This function free all the memory used by all the variables
  * in the list.
  */
 void vars_prune(struct vars *vars, struct session *sess, struct stream *strm)
@@ -356,7 +356,7 @@ static int sample_store(struct vars *vars, const char *name, struct sample *smp)
 		}
 	} else {
 
-		/* Check memory avalaible. */
+		/* Check memory available. */
 		if (!var_accounting_add(vars, smp->sess, smp->strm, sizeof(struct var)))
 			return 0;
 
@@ -489,9 +489,9 @@ static int smp_conv_clear(const struct arg *args, struct sample *smp, void *priv
 	return sample_clear_stream(args[0].data.var.name, args[0].data.var.scope, smp);
 }
 
-/* This fucntions check an argument entry and fill it with a variable
+/* This functions check an argument entry and fill it with a variable
  * type. The argumen must be a string. If the variable lookup fails,
- * the function retuns 0 and fill <err>, otherwise it returns 1.
+ * the function returns 0 and fill <err>, otherwise it returns 1.
  */
 int vars_check_arg(struct arg *arg, char **err)
 {
@@ -605,7 +605,7 @@ int vars_get_by_name(const char *name, size_t len, struct sample *smp)
 	default:         vars = &smp->strm->vars_reqres; break;
 	}
 
-	/* Check if the scope is avalaible a this point of processing. */
+	/* Check if the scope is available a this point of processing. */
 	if (vars->scope != scope)
 		return 0;
 
@@ -621,7 +621,7 @@ int vars_get_by_name(const char *name, size_t len, struct sample *smp)
 }
 
 /* this function fills a sample with the
- * content of the varaible described by <var_desc>. Returns 1
+ * content of the variable described by <var_desc>. Returns 1
  * if the sample is filled, otherwise it returns 0.
  */
 int vars_get_by_desc(const struct var_desc *var_desc, struct sample *smp)
@@ -639,7 +639,7 @@ int vars_get_by_desc(const struct var_desc *var_desc, struct sample *smp)
 	default:         vars = &smp->strm->vars_reqres; break;
 	}
 
-	/* Check if the scope is avalaible a this point of processing. */
+	/* Check if the scope is available a this point of processing. */
 	if (vars->scope != var_desc->scope)
 		return 0;
 

--- a/src/xxhash.c
+++ b/src/xxhash.c
@@ -51,10 +51,10 @@ You can contact the author at :
 // #define XXH_ACCEPT_NULL_INPUT_POINTER 1
 
 // XXH_FORCE_NATIVE_FORMAT :
-// By default, xxHash library provides endian-independant Hash values, based on little-endian convention.
+// By default, xxHash library provides endian-independent Hash values, based on little-endian convention.
 // Results are therefore identical for little-endian and big-endian CPU.
 // This comes at a performance cost for big-endian CPU, since some swapping is required to emulate little-endian format.
-// Should endian-independance be of no importance for your application, you may set the #define below to 1.
+// Should endian-independence be of no importance for your application, you may set the #define below to 1.
 // It will improve speed for Big-endian CPU.
 // This option has no impact on Little_Endian CPU.
 #define XXH_FORCE_NATIVE_FORMAT 0

--- a/tests/filltab25.c
+++ b/tests/filltab25.c
@@ -2,7 +2,7 @@
  * experimental weighted round robin scheduler - (c) 2007 willy tarreau.
  *
  * This filling algorithm is excellent at spreading the servers, as it also
- * takes care of keeping the most uniform distance between occurences of each
+ * takes care of keeping the most uniform distance between occurrences of each
  * server, by maximizing this distance. It reduces the number of variables
  * and expensive operations.
  */


### PR DESCRIPTION
Hi,

I found some typos while reading the documentation so I ended up running a tool called `misspell` on the repo that basically fixes common misspells.
Reviewed the result, did some changes, but I think we should be ok with what's left here.

Let me know if you want to break this change into smaller changes or if there are some elements I might have missed.

Thanks
Jospeh
