### PR TITLE
IPv6: properly format an address coming from IPv6 socket as hex in lf_ip

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -1153,8 +1153,21 @@ char *lf_ip(char *dst, const struct sockaddr *sockaddr, size_t size, const struc
 	char pn[INET6_ADDRSTRLEN];
 
 	if (node->options & LOG_OPT_HEXA) {
-		const unsigned char *addr = (const unsigned char *)&((struct sockaddr_in *)sockaddr)->sin_addr.s_addr;
-		iret = snprintf(dst, size, "%02X%02X%02X%02X", addr[0], addr[1], addr[2], addr[3]);
+		unsigned char *addr = NULL;
+		switch (sockaddr->sa_family) {
+		case AF_INET:
+			addr = (unsigned char *)&((struct sockaddr_in *)sockaddr)->sin_addr.s_addr;
+			iret = snprintf(dst, size, "%02X%02X%02X%02X", addr[0], addr[1], addr[2], addr[3]);
+			break;
+		case AF_INET6:
+			addr = (unsigned char *)&((struct sockaddr_in6 *)sockaddr)->sin6_addr.s6_addr;
+			iret = snprintf(dst, size, "%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X",
+					addr[0], addr[1], addr[2], addr[3], addr[4], addr[5], addr[6], addr[7],
+					addr[8], addr[9], addr[10], addr[11], addr[12], addr[13], addr[14], addr[15]);
+			break;
+		default:
+			return NULL;
+		}
 		if (iret < 0 || iret > size)
 			return NULL;
 		ret += iret;


### PR DESCRIPTION
Dear `haproxy` maintainers,

we've recently discovered an issue with formatting IPv6 addresses as hex strings (in e.g. `%{+X}ci`). This issue occurs e.g. when formatting `unique-id-format` as recommended in the docs: `%{+X}o\ %ci:%cp_%fi:%fp_%Ts_%rt:%pid`.

This pull request proposes a change that properly formats addresses from IPv4 sockets as 8-char hex-string and addresses from IPv6 sockets as 32-char hex-string.

The result looks like this:
```
Mar  8 13:28:21 hostname haproxy[11719]: ::1:38370 [00000000000000000000000000000001:95E2_00000000000000000000000000000001:1F98_5C825FE5_0001:2DC7] [1552048101] webfarm webfarm/server1.yourserver.com 0/0/0/0/0/0/0/0 302 183 - - --NN 1/1/0/0/0 0/0 "GET / HTTP/1.1"
Mar  8 13:28:21 hostname haproxy[11719]: 127.0.0.1:42268 [7F000001:A51C_7F000001:1F98_5C825FE5_0002:2DC7] [1552048101] webfarm webfarm/server1.yourserver.com 0/0/0/0/0/0/0/0 302 183 - - --NN 1/1/0/0/0 0/0 "GET / HTTP/1.1
```

Please also note that in case of an IPv6-bind processing IPv4-packets (e.g. bind to `::`) results in [IPv4-mapped-IPv6 addresses](https://en.wikipedia.org/wiki/IPv6#IPv4-mapped_IPv6_addresses) in **both text and hex form**, e.g.:
```
Mar  8 13:18:09 hostname haproxy[8586]: ::ffff:127.0.0.1:41874 [00000000000000000000FFFF7F000001:A392_00000000000000000000FFFF7F000001:1F98_5C825D81_0000:218A] [1552047489] webfarm webfarm/server1.yourserver.com 0/0/0/0/0/0/1/1 301 219 - - --NN 1/1/0/0/0 0/0 "GET / HTTP/1.1"
```
For the sake of consistency between `inet_ntop` result (IPv4-mapped-IPv6 address) and the hex formatter, the hex representation is kept as 32-char hex string.

Comments are welcome.
Please consider merging this patch into `master`.

Thank you.

Radek Zajic
[tech.showmax.com](https://tech.showmax.com/)