### PR TITLE
modescurity spoa (contrib) crash if Host header is absent in HTTP request

### DIFF
--- a/contrib/modsecurity/modsec_wrapper.c
+++ b/contrib/modsecurity/modsec_wrapper.c
@@ -325,7 +325,11 @@ int modsecurity_process(struct worker *worker, struct modsecurity_parameters *pa
 	req->content_type = apr_table_get(req->headers_in, "Content-Type");
 	req->content_encoding = apr_table_get(req->headers_in, "Content-Encoding");
 	req->hostname = apr_table_get(req->headers_in, "Host");
-	req->parsed_uri.hostname = chunk_strdup(req, req->hostname, strlen(req->hostname));
+	if (req->hostname != NULL) {
+			req->parsed_uri.hostname = chunk_strdup(req, req->hostname, strlen(req->hostname));
+		} else {
+			req->parsed_uri.hostname = NULL;
+	  }
 
 	lang = apr_table_get(req->headers_in, "Content-Languages");
 	if (lang != NULL) {


### PR DESCRIPTION
I discovered this bug when running OWASP regression tests against HAProxy + modsecurity-spoa (it's a POC to evaluate how it is working).
I found out that modsecurity spoa will crash when the request doesn't have any Host header.

## Output of `haproxy -vv` and `uname -a`
All HAProxy version / bug is related to the modsecurity spoa (contrib) and present in all versions.

## What's the configuration?
Not linked to any specific configuration, just using the modsecurity spoa makes it vulnerable to this bug.

## Steps to reproduce the behavior

1. Install and configure the modsecurity spoa, configure haproxy to check all its request with modsecuirty (cf. https://github.com/haproxy/haproxy/blob/master/contrib/modsecurity/README which by the way have some erronous information in it, I'll made another pull request later).
If you don't want to bother with compiling and such, there is a pretty good Docker image there : https://github.com/jcmoraisjr/modsecurity-spoa/blob/master/rootfs/Dockerfile. You'll stil have to configure HAProxy to use it, as explained in the README file.
2. curl -i -H "Host:" http://your.haproxy.domain

## Actual behavior
The modsecurity spoa just crash.
That could be annoying, even if it is configured to restart by itself (systemd or docker rule to do so), because during the time it gets up again, haproxy would not check the requests againts modsecurity (this could be mitigated by using an HAProxy rule rejecting all HTTP requests with no Host header). That means someone who wants to attack a site protected using HAProxy + modsecurity-spoa could disable modsecurity checks by doing HTTP requests without host, than all subsequent requests would be treated by HAProxy bypassing all modsecurity checks.

## Expected behavior
modsecurity does not crash, and if using the OWASP CRS rules, the request is blocked because it is missing the Host header.

## Do you have any idea what may have caused this?
This is because in modsec_wrapper.c, at line 328, strlen(req->hostname) will crash because req->hostname is NULL.

## Do you have an idea how to solve the issue?
Checking if req->hostname is NULL before trying to do the chunk_strdup.
```
  if (req->hostname != NULL) {
		req->parsed_uri.hostname = chunk_strdup(req, req->hostname, strlen(req->hostname));
	} else {
		req->parsed_uri.hostname = NULL;
  }
```
I tried that patch, it works fine, no crash, and the query is then correctly intercepted by the modsecuirty / CRS rules :
1556193994.134313 [00] [client 127.0.0.1] ModSecurity: Warning. Operator EQ matched 0 at REQUEST_HEADERS. [file "/etc/modsecurity/owasp-modsecurity-crs/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf"] [line "605"] [id "920280"] [msg "Request Missing a Host Header"] [severity "WARNING"] [ver "OWASP_CRS/3.1.0"] [tag "application-multi"] [tag "language-multi"] [tag "platform-multi"] [tag "attack-protocol"] [tag "OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER_HOST"] [tag "WASCTC/WASC-21"] [tag "OWASP_TOP_10/A7"] [tag "PCI/6.5.10"] [hostname "c3cfbbe6058a"] [uri "http://www.google.com/../../index.html"] [unique_id ""]

This patch could be applyed to any versions of HAProxy proposing the modsecurity contrib.
