### PR TITLE
BUILD: extend travis-ci matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,12 @@ dist: xenial
 
 language: c
 
+env:
+  global:
+    - FLAGS="USE_ZLIB=1 USE_PCRE=1 USE_LUA=1 USE_OPENSSL=1"
+    - SSL_LIB=${HOME}/opt/lib
+    - SSL_INC=${HOME}/opt/include
+
 addons:
   apt:
     packages: [ liblua5.3-dev ]
@@ -12,15 +18,33 @@ matrix:
   - os: linux
     compiler: gcc
     env: TARGET=linux2628 FLAGS=
+  - os: linux-ppc64le
+    compiler: gcc
+    env: TARGET=linux2628 OPENSSL_VERSION=1.1.1b LABEL="linux-ppc64le"
   - os: linux
     compiler: gcc
-    env: TARGET=linux2628 FLAGS="USE_ZLIB=1 USE_PCRE=1 USE_LUA=1 USE_OPENSSL=1"
+    env: TARGET=linux2628 OPENSSL_VERSION=1.1.1b
+  - os: linux
+    compiler: gcc
+    env: TARGET=linux2628 OPENSSL_VERSION=1.1.0j
+  - os: linux
+    compiler: gcc
+    env: TARGET=linux2628 OPENSSL_VERSION=1.0.2r
+  - os: linux
+    compiler: gcc
+    env: TARGET=linux2628 LIBRESSL_VERSION=2.9.1
+  - os: linux
+    compiler: gcc
+    env: TARGET=linux2628 LIBRESSL_VERSION=2.8.3
+  - os: linux
+    compiler: gcc
+    env: TARGET=linux2628 LIBRESSL_VERSION=2.7.5
   - os: linux
     compiler: clang
     env: TARGET=linux2628 FLAGS=
   - os: osx
     compiler: clang
-    env: TARGET=generic FLAGS=
+    env: TARGET=generic FLAGS="USE_OPENSSL=1" OPENSSL_VERSION=1.1.1b
 
 install:
   - git clone https://github.com/VTest/VTest.git ../vtest
@@ -32,10 +56,15 @@ before_script:
   # the unix socket path names exceed the maximum allowed
   # length.
   - sed -i'.original' '/TESTDIR=.*haregtests/s/haregtests-.*XXXXXX/regtest.XXX/' scripts/run-regtests.sh
+  - scripts/build-ssl.sh > build-ssl.log 2>&1 || (cat build-ssl.log && exit 1)
 
 script:
   - make CC=$CC V=1 TARGET=$TARGET $FLAGS
+  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then export LD_LIBRARY_PATH="${HOME}/opt/lib:${LD_LIBRARY_PATH:-}"; fi
+  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then export DYLD_LIBRARY_PATH="${HOME}/opt/lib:${DYLD_LIBRARY_PATH:-}"; fi
   - ./haproxy -vv
+  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then ldd haproxy; fi
+  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then otool -L haproxy; fi
   - env VTEST_PROGRAM=../vtest/vtest make reg-tests
 
 after_failure:

--- a/scripts/build-ssl.sh
+++ b/scripts/build-ssl.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+set -eux
+
+download_openssl () {
+    if [ ! -f "download-cache/openssl-${OPENSSL_VERSION}.tar.gz" ]; then
+        wget -P download-cache/ \
+            "https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz"
+    fi
+}
+
+build_openssl_linux () {
+    (
+        cd "openssl-${OPENSSL_VERSION}/"
+        ./config shared --prefix="${HOME}/opt" --openssldir="${HOME}/opt" -DPURIFY
+        make all install_sw
+    )
+}
+
+build_openssl_osx () {
+    (
+        cd "openssl-${OPENSSL_VERSION}/"
+        ./Configure darwin64-x86_64-cc shared \
+            --prefix="${HOME}/opt" --openssldir="${HOME}/opt" -DPURIFY
+        make depend all install_sw
+    )
+}
+
+build_openssl () {
+    if [ "$(cat ${HOME}/opt/.openssl-version)" != "${OPENSSL_VERSION}" ]; then
+        tar zxf "download-cache/openssl-${OPENSSL_VERSION}.tar.gz"
+        if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
+            build_openssl_osx
+        elif [ "${TRAVIS_OS_NAME}" = "linux" ]; then
+            build_openssl_linux
+        fi
+        echo "${OPENSSL_VERSION}" > "${HOME}/opt/.openssl-version"
+    fi
+}
+
+download_libressl () {
+    if [ ! -f "download-cache/libressl-${LIBRESSL_VERSION}.tar.gz" ]; then
+        wget -P download-cache/ \
+	    "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-${LIBRESSL_VERSION}.tar.gz"
+    fi
+}
+
+build_libressl() {
+    (
+        cd "libressl-${LIBRESSL_VERSION}/"
+        ./configure --prefix="${HOME}/opt"
+        make all install
+    )
+}
+
+build_libressl () {
+    if [ "$(cat ${HOME}/opt/.libressl-version)" != "${LIBRESSL_VERSION}" ]; then
+        tar zxf "download-cache/libressl-${LIBRESSL_VERSION}.tar.gz"
+        (
+           cd "libressl-${LIBRESSL_VERSION}/"
+           ./configure --prefix="${HOME}/opt"
+            make all install
+        )
+        echo "${LIBRESSL_VERSION}" > "${HOME}/opt/.libressl-version"
+    fi
+}
+
+if [ ! -z ${LIBRESSL_VERSION+x} ]; then
+	download_libressl
+	build_libressl
+fi
+
+if [ ! -z ${OPENSSL_VERSION+x} ]; then
+	download_openssl
+	build_openssl
+fi
+
+


### PR DESCRIPTION
added openssl-1.0.2, 1.1.0, 1.1.1, libressl-2.7.5, 2.8.3, 2.9.1
added linux-ppc64le image

libressl builds are yet broken. they will get repaired after separate patch (already sent to mailing list)