### PR TITLE
MINOR: doc: Remove -Ds option in man page

### DIFF
--- a/doc/haproxy.1
+++ b/doc/haproxy.1
@@ -78,10 +78,6 @@ starting up.
 Start in daemon mode.
 
 .TP
-\fB\-Ds\fP
-Start in systemd daemon mode, keeping a process in foreground.
-
-.TP
 \fB\-q\fP
 Disable messages on output.
 


### PR DESCRIPTION
`-Ds` option should be removed from man page. It is no longer supported as this commit shows: https://github.com/haproxy/haproxy/commit/095ba4c2428ec8bcccb134b3d24f07de2aabbdcd

I noticed that the option has already gone when upgrading my haproxy from 1.7 to 2.0-dev7. I have had the old and new haproxy running as a pod on my Kubernetes cluster, therefore, it is important for me to know what option is provided to keep the process in the foreground.

After upgrading, I was able to make my haproxy running successfully by removing `-Ds` option and `daemon` global parameter in the config. Thank you.