### PR TITLE
add a vhost setting  per backend

### DIFF
--- a/doc/configuration.txt
+++ b/doc/configuration.txt
@@ -8012,9 +8012,9 @@ retry-on [list of keywords]
 
       all-retryable-errors
                         retry request for any error that are considered
-			retryable. This currently activates "conn-failure",
-			"empty-response", "junk-response", "response-timeout",
-			"0rtt-rejected", "500", "502", "503", and "504".
+                        retryable. This currently activates "conn-failure",
+                        "empty-response", "junk-response", "response-timeout",
+                        "0rtt-rejected", "500", "502", "503", and "504".
 
   Using this directive replaces any previous settings with the new ones; it is
   not cumulative.
@@ -12542,10 +12542,10 @@ vhost <hostname>
   backend vhost-example
     mode http
 
-	option httpchk GET /healthcheck
-	http-check expect status 200
-	server srv-host 10.10.0.1:8080 vhost myapp.naeast-1a.example.com check
-	server srv-host 10.20.0.1:8080 vhost myapp.nawest-2b.example.com check
+    option httpchk GET /healthcheck
+    http-check expect status 200
+    server srv-host 10.10.0.1:8080 vhost myapp.naeast-1a.example.com check
+    server srv-host 10.20.0.1:8080 vhost myapp.nawest-2b.example.com check
 
   See also : "http-send-name-header", "httpchk"
 

--- a/doc/configuration.txt
+++ b/doc/configuration.txt
@@ -12531,6 +12531,24 @@ verifyhost <hostname>
   handshake is aborted. The hostnames in the server-provided certificate may
   include wildcards. See also "verify", "sni" and "no-verifyhost" options.
 
+vhost <hostname>
+  The "vhost" parameter is used to specify the hostname for a backend. 
+  It will be set in the Host header in requests forwarded to the backend, 
+  in HTTP healthchecks and when establishing TLS connections (TLS SNI).
+  It is required when using services that rely on the Host header for
+  routing connections (kubernetes ingress, ALB, other haproxy, etc...).
+
+  Examples :
+  backend vhost-example
+    mode http
+
+	option httpchk GET /healthcheck
+	http-check expect status 200
+	server srv-host 10.10.0.1:8080 vhost myapp.naeast-1a.example.com check
+	server srv-host 10.20.0.1:8080 vhost myapp.nawest-2b.example.com check
+
+  See also : "http-send-name-header", "httpchk"
+
 weight <weight>
   The "weight" parameter is used to adjust the server's weight relative to
   other servers. All servers will receive a load proportional to their weight

--- a/include/proto/proto_http.h
+++ b/include/proto/proto_http.h
@@ -40,6 +40,7 @@ int http_process_request(struct stream *s, struct channel *req, int an_bit);
 int http_process_tarpit(struct stream *s, struct channel *req, int an_bit);
 int http_wait_for_request_body(struct stream *s, struct channel *req, int an_bit);
 int http_send_name_header(struct stream *s, struct proxy* be, const char* svr_name);
+int http_send_vhost_header(struct stream *s, struct proxy* be, const char* vhost);
 int http_wait_for_response(struct stream *s, struct channel *rep, int an_bit);
 int http_process_res_common(struct stream *s, struct channel *rep, int an_bit, struct proxy *px);
 int http_request_forward_body(struct stream *s, struct channel *req, int an_bit);
@@ -86,6 +87,7 @@ void htx_res_set_status(unsigned int status, const char *reason, struct stream *
 void htx_check_request_for_cacheability(struct stream *s, struct channel *req);
 void htx_check_response_for_cacheability(struct stream *s, struct channel *res);
 int htx_send_name_header(struct stream *s, struct proxy *be, const char *srv_name);
+int htx_send_vhost_header(struct stream *s, struct proxy *be, const char *vhost);
 void htx_perform_server_redirect(struct stream *s, struct stream_interface *si);
 void htx_server_error(struct stream *s, struct stream_interface *si, int err, int finst, const struct buffer *msg);
 void htx_reply_and_close(struct stream *s, short status, struct buffer *msg);

--- a/include/types/server.h
+++ b/include/types/server.h
@@ -271,7 +271,7 @@ struct server {
 	int puid;				/* proxy-unique server ID, used for SNMP, and "first" LB algo */
 	int tcp_ut;                             /* for TCP, user timeout */
 
-	char *vhost;							/* the host header to send per backend */
+	char *vhost;                            /* the host header to send per backend */
 
 	int do_check;                           /* temporary variable used during parsing to denote if health checks must be enabled */
 	int do_agent;                           /* temporary variable used during parsing to denote if an auxiliary agent check must be enabled */

--- a/include/types/server.h
+++ b/include/types/server.h
@@ -271,6 +271,8 @@ struct server {
 	int puid;				/* proxy-unique server ID, used for SNMP, and "first" LB algo */
 	int tcp_ut;                             /* for TCP, user timeout */
 
+	char *vhost;							/* the host header to send per backend */
+
 	int do_check;                           /* temporary variable used during parsing to denote if health checks must be enabled */
 	int do_agent;                           /* temporary variable used during parsing to denote if an auxiliary agent check must be enabled */
 	struct check check;                     /* health-check specific configuration */

--- a/src/backend.c
+++ b/src/backend.c
@@ -1672,6 +1672,11 @@ int connect_server(struct stream *s)
 				srv_conn->flags |= CO_FL_PRIVATE;
 			}
 		}
+
+		if (srv->vhost) {
+			ssl_sock_set_servername(srv_conn, srv->vhost);
+			srv_conn->flags |= CO_FL_PRIVATE;
+		}
 #endif /* USE_OPENSSL */
 
 	}

--- a/src/server.c
+++ b/src/server.c
@@ -1735,7 +1735,7 @@ static void srv_settings_cpy(struct server *srv, struct server *src, int srv_tmp
 		srv->cklen  = src->cklen;
 	}
 	srv->use_ssl                  = src->use_ssl;
-	srv->vhost					  = src->vhost;
+	srv->vhost                    = src->vhost;
 	srv->check.addr = srv->agent.addr = src->check.addr;
 	srv->check.use_ssl            = src->check.use_ssl;
 	srv->check.port               = src->check.port;

--- a/src/server.c
+++ b/src/server.c
@@ -1735,6 +1735,7 @@ static void srv_settings_cpy(struct server *srv, struct server *src, int srv_tmp
 		srv->cklen  = src->cklen;
 	}
 	srv->use_ssl                  = src->use_ssl;
+	srv->vhost					  = src->vhost;
 	srv->check.addr = srv->agent.addr = src->check.addr;
 	srv->check.use_ssl            = src->check.use_ssl;
 	srv->check.port               = src->check.port;
@@ -2527,6 +2528,11 @@ int parse_server(const char *file, int linenum, char **args, struct proxy *curpr
 					p = e;
 				}
 
+				cur_arg += 2;
+			}
+			else if (!strcmp(args[cur_arg], "vhost")) {
+				free(newsrv->vhost);
+				newsrv->vhost = strdup(args[cur_arg + 1]);
 				cur_arg += 2;
 			}
 			else if (!strcmp(args[cur_arg], "rise")) {

--- a/src/stream.c
+++ b/src/stream.c
@@ -2449,6 +2449,15 @@ struct task *process_stream(struct task *t, void *context, unsigned short state)
 				http_send_name_header(s, s->be, objt_server(s->target)->id);
 			}
 
+			/* Now we can add the server vhost to a header (if requested) */
+			/* check for HTTP mode and proxy server_name_hdr_name != NULL */
+			if (si_state_in(si_b->state, SI_SB_CON|SI_SB_RDY|SI_SB_EST) &&
+			    (s->be->mode == PR_MODE_HTTP) &&
+			    objt_server(s->target) &&
+			    (objt_server(s->target)->vhost != NULL)) {
+				http_send_vhost_header(s, s->be, objt_server(s->target)->vhost);
+			}
+
 			srv = objt_server(s->target);
 			if (si_b->state == SI_ST_ASS && srv && srv->rdr_len && (s->flags & SF_REDIRECTABLE))
 				http_perform_server_redirect(s, si_b);

--- a/tests/test-server-vhost.cfg
+++ b/tests/test-server-vhost.cfg
@@ -1,0 +1,19 @@
+# Test Virtual Host
+global
+       maxconn 100
+
+defaults
+	mode http
+	timeout client 10000
+	timeout server 10000
+	timeout connect 10000
+	balance roundrobin
+
+listen send-vhost
+	bind :8000
+
+	server srv-host 127.0.0.1:8080 vhost api.example.com
+
+	# Add headers containing the correct values for test verification
+	reqadd X-test-server-name-header:\ Host
+	reqadd X-test-server-name-value:\ api.example.com


### PR DESCRIPTION
Add a vhost setting per backend. It sets the host header for the backend in http requests, http healthchecks and TLS connections.

This is required to support services using the host header for routing (kube ingress, ALB, other load balancer...). 