### PR TITLE
MINOR: connection: add TCP keep-alive parameters

### DIFF
--- a/doc/configuration.txt
+++ b/doc/configuration.txt
@@ -2530,6 +2530,9 @@ tcp-check connect                         -          -         X         X
 tcp-check expect                          -          -         X         X
 tcp-check send                            -          -         X         X
 tcp-check send-binary                     -          -         X         X
+tcp-keepalive-time                        X          X         X         X
+tcp-keepalive-interval                    X          X         X         X
+tcp-keepalive-count                       X          X         X         X
 tcp-request connection                    -          X         X         -
 tcp-request content                       -          X         X         X
 tcp-request inspect-delay                 -          X         X         X
@@ -5958,9 +5961,10 @@ no option clitcpka
   components decides to expire a session which has remained idle for too long.
 
   Enabling socket-level TCP keep-alives makes the system regularly send packets
-  to the other end of the connection, leaving it active. The delay between
-  keep-alive probes is controlled by the system only and depends both on the
-  operating system and its tuning parameters.
+  to the other end of the connection, leaving it active. The operating system
+  provides defaults for keep-alive idle time, probe interval and probe retry
+  count, but they are also configurable using "tcp-keepalive-time",
+  "tcp-keepalive-interval" and "tcp-keepalive-count".
 
   It is important to understand that keep-alive packets are neither emitted nor
   received at the application level. It is only the network stacks which sees
@@ -5977,7 +5981,8 @@ no option clitcpka
   If this option has been enabled in a "defaults" section, it can be disabled
   in a specific instance by prepending the "no" keyword before it.
 
-  See also : "option srvtcpka", "option tcpka"
+  See also : "option srvtcpka", "option tcpka", "tcp-keepalive-time",
+             "tcp-keepalive-interval", "tcp-keepalive-count"
 
 
 option contstats
@@ -7159,9 +7164,10 @@ no option srvtcpka
   components decides to expire a session which has remained idle for too long.
 
   Enabling socket-level TCP keep-alives makes the system regularly send packets
-  to the other end of the connection, leaving it active. The delay between
-  keep-alive probes is controlled by the system only and depends both on the
-  operating system and its tuning parameters.
+  to the other end of the connection, leaving it active. The operating system
+  provides defaults for keep-alive idle time, retry interval and probe count,
+  but they are also configurable using "tcp-keepalive-time",
+  "tcp-keepalive-interval" and "tcp-keepalive-count".
 
   It is important to understand that keep-alive packets are neither emitted nor
   received at the application level. It is only the network stacks which sees
@@ -7178,7 +7184,8 @@ no option srvtcpka
   If this option has been enabled in a "defaults" section, it can be disabled
   in a specific instance by prepending the "no" keyword before it.
 
-  See also : "option clitcpka", "option tcpka"
+  See also : "option clitcpka", "option tcpka", "tcp-keepalive-time",
+             "tcp-keepalive-interval", "tcp-keepalive-count"
 
 
 option ssl-hello-chk
@@ -7362,9 +7369,10 @@ option tcpka
   components decides to expire a session which has remained idle for too long.
 
   Enabling socket-level TCP keep-alives makes the system regularly send packets
-  to the other end of the connection, leaving it active. The delay between
-  keep-alive probes is controlled by the system only and depends both on the
-  operating system and its tuning parameters.
+  to the other end of the connection, leaving it active. The operating system
+  provides defaults for keep-alive idle time, retry interval and probe count,
+  but they are also configurable using "tcp-keepalive-time",
+  "tcp-keepalive-interval" and "tcp-keepalive-count".
 
   It is important to understand that keep-alive packets are neither emitted nor
   received at the application level. It is only the network stacks which sees
@@ -7383,7 +7391,8 @@ option tcpka
   "option srvtcpka" when the configuration is split between frontends and
   backends.
 
-  See also : "option clitcpka", "option srvtcpka"
+  See also : "option clitcpka", "option srvtcpka", "tcp-keepalive-time",
+             "tcp-keepalive-interval", "tcp-keepalive-count"
 
 
 option tcplog
@@ -9231,6 +9240,74 @@ tcp-check send-binary <hexstring>
 
   See also : "option tcp-check", "tcp-check connect", "tcp-check expect",
              "tcp-check send", tune.chksize
+
+
+tcp-keepalive-time <number>
+  Set the idle time before TCP keep-alive probes are sent
+  May be used in sections :   defaults | frontend | listen | backend
+                                 yes   |    yes   |   yes  |   yes
+  Arguments :
+    <number>  is the number of seconds a connection needs to be idle before TCP
+              begins sending out keep-alive probes.
+
+  If enabled using "option tcpka", "option clitcpka" or "option srvtcpka",
+  TCP keep-alive probes are sent to confirm that a connection is still active.
+  This is useful not only for the connection endpoints, but also for in-between
+  systems that track the state of the connection, such as firewalls and NAT
+  gateways.
+
+  The "tcp-keepalive-time" parameter specifies how long a connection has to
+  idle before TCP keep-alive probes are sent.
+
+  Please note that this has nothing to do with HTTP keep-alive.
+
+  See also : "option tcpka", "option clitcpka", "option srvtcpka",
+             "tcp-keepalive-interval", "tcp-keepalive-count"
+
+
+tcp-keepalive-interval <number>
+  Set the wait interval between TCP keep-alive probes
+  May be used in sections :   defaults | frontend | listen | backend
+                                 yes   |    yes   |   yes  |   yes
+  Arguments :
+    <number>  is the number of seconds to wait between keep-alive probes.
+
+  If enabled using "option tcpka", "option clitcpka" or "option srvtcpka",
+  TCP keep-alive probes are sent to confirm that a connection is still active.
+  This is useful not only for the connection endpoints, but also for in-between
+  systems that track the state of the connection, such as firewalls and NAT
+  gateways.
+
+  The "tcp-keepalive-interval" parameter specifies the interval between
+  keep-alive probes.
+
+  Please note that this has nothing to do with HTTP keep-alive.
+
+  See also : "option tcpka", "option clitcpka", "option srvtcpka",
+             "tcp-keepalive-time", "tcp-keepalive-count"
+
+
+tcp-keepalive-count <number>
+  Set the TCP keep-alive probe count before giving up the connection
+  May be used in sections :   defaults | frontend | listen | backend
+                                 yes   |    yes   |   yes  |   yes
+  Arguments :
+    <number>  is the number of unanswered keep-alive probes to send before
+              giving up the connection.
+
+  If enabled using "option tcpka", "option clitcpka" or "option srvtcpka",
+  TCP keep-alive probes are sent to confirm that a connection is still active.
+  This is useful not only for the connection endpoints, but also for in-between
+  systems that track the state of the connection, such as firewalls and NAT
+  gateways.
+
+  The "tcp-keepalive-count" parameter specifies the number of unanswered
+  keep-alive probes to send before giving up the connection.
+
+  Please note that this has nothing to do with HTTP keep-alive.
+
+  See also : "option tcpka", "option clitcpka", "option srvtcpka",
+             "tcp-keepalive-time", "tcp-keepalive-interval"
 
 
 tcp-request connection <action> [{if | unless} <condition>]

--- a/include/types/proxy.h
+++ b/include/types/proxy.h
@@ -431,6 +431,9 @@ struct proxy {
 	int uuid;				/* universally unique proxy ID, used for SNMP */
 	unsigned int backlog;			/* force the frontend's listen backlog */
 	unsigned long bind_proc;		/* bitmask of processes using this proxy */
+	int tcp_keepalive_time;			/* TCP keep-alive idle time */
+	int tcp_keepalive_interval;		/* TCP keep-alive probe retry interval */
+	int tcp_keepalive_count;		/* TCP keep-alive probe retry count */
 
 	/* warning: these structs are huge, keep them at the bottom */
 	struct sockaddr_storage dispatch_addr;	/* the default address to connect to */

--- a/src/cfgparse-listen.c
+++ b/src/cfgparse-listen.c
@@ -3257,6 +3257,36 @@ stats_error_parsing:
 		if (alertif_too_many_args(1, file, linenum, args, &err_code))
 			goto out;
 	}
+	else if (!strcmp(args[0], "tcp-keepalive-time")) {  /* TCP keep-alive idle time */
+		if (*(args[1]) == 0) {
+			ha_alert("parsing [%s:%d] : '%s' expects an integer argument.\n", file, linenum, args[0]);
+			err_code |= ERR_ALERT | ERR_FATAL;
+			goto out;
+		}
+		curproxy->tcp_keepalive_time = atol(args[1]);
+		if (alertif_too_many_args(1, file, linenum, args, &err_code))
+			goto out;
+	}
+	else if (!strcmp(args[0], "tcp-keepalive-interval")) {  /* TCP keep-alive probe retry interval */
+		if (*(args[1]) == 0) {
+			ha_alert("parsing [%s:%d] : '%s' expects an integer argument.\n", file, linenum, args[0]);
+			err_code |= ERR_ALERT | ERR_FATAL;
+			goto out;
+		}
+		curproxy->tcp_keepalive_interval = atol(args[1]);
+		if (alertif_too_many_args(1, file, linenum, args, &err_code))
+			goto out;
+	}
+	else if (!strcmp(args[0], "tcp-keepalive-count")) {  /* TCP keep-alive probe retry count */
+		if (*(args[1]) == 0) {
+			ha_alert("parsing [%s:%d] : '%s' expects an integer argument.\n", file, linenum, args[0]);
+			err_code |= ERR_ALERT | ERR_FATAL;
+			goto out;
+		}
+		curproxy->tcp_keepalive_count = atol(args[1]);
+		if (alertif_too_many_args(1, file, linenum, args, &err_code))
+			goto out;
+	}
 	else if (!strcmp(args[0], "dispatch")) {  /* dispatch address */
 		struct sockaddr_storage *sk;
 		int port1, port2;

--- a/src/session.c
+++ b/src/session.c
@@ -234,6 +234,44 @@ int session_accept_fd(struct listener *l, int cfd, struct sockaddr_storage *addr
 		if (p->options & PR_O_TCP_CLI_KA)
 			setsockopt(cfd, SOL_SOCKET, SO_KEEPALIVE, (char *) &one, sizeof(one));
 
+#ifdef TCP_KEEPALIVE
+		/* Darwin */
+		if (p->tcp_keepalive_time &&
+				(setsockopt(cfd, IPPROTO_TCP, TCP_KEEPALIVE,
+					    &p->tcp_keepalive_time,
+					    sizeof(p->tcp_keepalive_time)) == -1)) {
+			DPRINTF(stderr, "Failed to set TCP keepalive time: %s\n", strerror(errno));
+		}
+#endif
+
+#ifdef TCP_KEEPIDLE
+		/* Linux, NetBSD */
+		if (p->tcp_keepalive_time &&
+				(setsockopt(cfd, IPPROTO_TCP, TCP_KEEPIDLE,
+					    &p->tcp_keepalive_time,
+					    sizeof(p->tcp_keepalive_time)) == -1)) {
+			DPRINTF(stderr, "Failed to set TCP keepalive time: %s\n", strerror(errno));
+		}
+#endif
+
+#ifdef TCP_KEEPINTVL
+		if (p->tcp_keepalive_interval &&
+				(setsockopt(cfd, IPPROTO_TCP, TCP_KEEPINTVL,
+					    &p->tcp_keepalive_interval,
+					    sizeof(p->tcp_keepalive_interval)) == -1)) {
+			DPRINTF(stderr, "Failed to set TCP keepalive interval: %s\n", strerror(errno));
+		}
+#endif
+
+#ifdef TCP_KEEPCNT
+		if (p->tcp_keepalive_count &&
+				(setsockopt(cfd, IPPROTO_TCP, TCP_KEEPCNT,
+					    &p->tcp_keepalive_count,
+					    sizeof(p->tcp_keepalive_count)) == -1)) {
+			DPRINTF(stderr, "Failed to set TCP keepalive count: %s\n", strerror(errno));
+		}
+#endif
+
 		if (p->options & PR_O_TCP_NOLING)
 			fdtab[cfd].linger_risk = 1;
 

--- a/tests/test-tcp-keepalive.cfg
+++ b/tests/test-tcp-keepalive.cfg
@@ -1,0 +1,36 @@
+# Test configuration to try all four combinations of TCP keep-alives
+# enabled/disabled on the frontent/backend.
+
+frontend keepalive-to-keepalive
+	bind :8000
+	option clitcpka
+	tcp-keepalive-time 5
+	tcp-keepalive-interval 5
+	tcp-keepalive-count 3
+	use_backend keepalive
+
+frontend keepalive-to-nokeepalive
+	bind :8001
+	option clitcpka
+	tcp-keepalive-time 5
+	tcp-keepalive-interval 5
+	tcp-keepalive-count 3
+	use_backend nokeepalive
+
+frontend nokeepalive-to-keepalive
+	bind :8002
+	use_backend keepalive
+
+frontend nokeepalive-to-nokeepalive
+	bind :8003
+	use_backend nokeepalive
+
+backend keepalive
+	option srvtcpka
+	tcp-keepalive-time 7
+	tcp-keepalive-interval 7
+	tcp-keepalive-count 3
+	server s1 127.0.0.1:8080
+
+backend nokeepalive
+	server s1 127.0.0.1:8081


### PR DESCRIPTION
Add configuration parameters to control TCP keep-alives:
* tcp-keepalive-time: Idle time before keep-alive probes are sent
* tcp-keepalive-interval: Interval between keep-alive probes
* tcp-keepalive-count: Number of keep-alive probes to send before giving up

Tested with TCP and HTTP, and with different settings in the default, listen, frontend and backend sections.

Potential issues:
* Only tested on Linux.
* Darwin `#ifdef TCP_KEEPALIVE` implemented but untested.
* No Windows support.

Rationale:
* HAProxy only allows enabling/disabling TCP keep-alives; not controlling parameters.
* System default parameters controllable using sysctl.
* System defaults apply to all connections. Default idle time: 7200 seconds, as required by RFC 1122.
* The `sysctl` command does not work on Docker containers due to read-only procfs.
* The Docker `privileged` flag could have worked, but is unsupported on AWS Fargate.
* The Docker `sysctl` flag could have worked, but is unsupported on AWS Fargate.
* The Docker Linux capability flags could have worked, but are unsupported on AWS Fargate.
* I'm behind a Cisco Meraki NAT gateway that has a fixed TCP NAT timeout of 300 seconds, meaning connections are dropped before the TCP keep-alive idle time kicks in (default 7200 seconds on Linux). Meraki support confirms the fixed 300 second timeout.
* Instead of requiring all clients to increase the TCP keep-alive probe frequency, fix it centrally by enabling parameters in HAProxy.