### PR TITLE
MINOR: remove limit of 1k socket connections with systemd

### DIFF
--- a/contrib/systemd/haproxy.service.in
+++ b/contrib/systemd/haproxy.service.in
@@ -11,6 +11,7 @@ ExecStart=@SBINDIR@/haproxy -Ws -f $CONFIG -p $PIDFILE $EXTRAOPTS
 ExecReload=@SBINDIR@/haproxy -f $CONFIG -c -q $EXTRAOPTS
 ExecReload=/bin/kill -USR2 $MAINPID
 KillMode=mixed
+LimitNOFILE=infinity
 Restart=always
 SuccessExitStatus=143
 Type=notify


### PR DESCRIPTION
systemd by default limits the max open files to 1k, which also limits the socket connections to 1k, the service script must be told to remove the limit.