### PR TITLE
MINOR: stick-table: allow sc-set-gpt0 to set value from an expression

### DIFF
--- a/doc/configuration.txt
+++ b/doc/configuration.txt
@@ -4465,11 +4465,12 @@ http-request sc-inc-gpc1(<sc-id>) [ { if | unless } <condition> ]
   counter designated by <sc-id>. If an error occurs, this action silently fails
   and the actions evaluation continues.
 
-http-request sc-set-gpt0(<sc-id>) <int> [ { if | unless } <condition> ]
+http-request sc-set-gpt0(<sc-id>) { <int> | <expr> }
+                                  [ { if | unless } <condition> ]
 
   This action sets the GPT0 tag according to the sticky counter designated by
-  <sc-id> and the value of <int>. The expected result is a boolean. If an error
-  occurs, this action silently fails and the actions evaluation continues.
+  <sc-id> and the value of <int>/<expr>. The expected result is a boolean. If an
+  error occurs, this action silently fails and the actions evaluation continues.
 
 http-request set-dst <expr> [ { if | unless } <condition> ]
 
@@ -4974,11 +4975,12 @@ http-response sc-inc-gpc1(<sc-id>) [ { if | unless } <condition> ]
   counter designated by <sc-id>. If an error occurs, this action silently fails
   and the actions evaluation continues.
 
-http-response sc-set-gpt0(<sc-id>) <int> [ { if | unless } <condition> ]
+http-response sc-set-gpt0(<sc-id>) { <int> | <expr> }
+                                   [ { if | unless } <condition> ]
 
   This action sets the GPT0 tag according to the sticky counter designated by
-  <sc-id> and the value of <int>. The expected result is a boolean. If an error
-  occurs, this action silently fails and the actions evaluation continues.
+  <sc-id> and the value of <int>/<expr>. The expected result is a boolean. If an
+  error occurs, this action silently fails and the actions evaluation continues.
 
 http-response send-spoe-group [ { if | unless } <condition> ]
 
@@ -9394,11 +9396,11 @@ tcp-request connection <action> [{if | unless} <condition>]
         counter designated by <sc-id>. If an error occurs, this action silently
         fails and the actions evaluation continues.
 
-    - sc-set-gpt0(<sc-id>) <int>:
+    - sc-set-gpt0(<sc-id>) { <int> | <expr> }:
         This action sets the GPT0 tag according to the sticky counter designated
-        by <sc-id> and the value of <int>. The expected result is a boolean. If
-        an error occurs, this action silently fails and the actions evaluation
-        continues.
+        by <sc-id> and the value of <int>/<expr>. The expected result is a
+        boolean. If an error occurs, this action silently fails and the actions
+        evaluation continues.
 
     - set-src <expr> :
       Is used to set the source IP address to the value of specified
@@ -9556,7 +9558,7 @@ tcp-request content <action> [{if | unless} <condition>]
     - { track-sc0 | track-sc1 | track-sc2 } <key> [table <table>]
     - sc-inc-gpc0(<sc-id>)
     - sc-inc-gpc1(<sc-id>)
-    - sc-set-gpt0(<sc-id>) <int>
+    - sc-set-gpt0(<sc-id>) { <int> | <expr> }
     - set-dst <expr>
     - set-dst-port <expr>
     - set-var(<var-name>) <expr>
@@ -9820,11 +9822,11 @@ tcp-response content <action> [{if | unless} <condition>]
         counter designated by <sc-id>. If an error occurs, this action fails
         silently and the actions evaluation continues.
 
-    - sc-set-gpt0(<sc-id>) <int> :
+    - sc-set-gpt0(<sc-id>) { <int> | <expr> }
         This action sets the GPT0 tag according to the sticky counter designated
-        by <sc-id> and the value of <int>. The expected result is a boolean. If
-        an error occurs, this action silently fails and the actions evaluation
-        continues.
+        by <sc-id> and the value of <int>/<expr>. The expected result is a
+        boolean. If an error occurs, this action silently fails and the actions
+        evaluation continues.
 
     - "silent-drop" :
         This stops the evaluation of the rules and makes the client-facing
@@ -9945,7 +9947,7 @@ tcp-request session <action> [{if | unless} <condition>]
     - { track-sc0 | track-sc1 | track-sc2 } <key> [table <table>]
     - sc-inc-gpc0(<sc-id>)
     - sc-inc-gpc1(<sc-id>)
-    - sc-set-gpt0(<sc-id>) <int>
+    - sc-set-gpt0(<sc-id>) { <int> | <expr> }
     - set-var(<var-name>) <expr>
     - unset-var(<var-name>)
     - silent-drop

--- a/include/types/action.h
+++ b/include/types/action.h
@@ -168,6 +168,7 @@ struct act_rule {
 		struct {
 			int sc;
 			long long int value;
+			struct sample_expr *expr;
 		} gpt;
 		struct track_ctr_prm trk_ctr;
 		struct {

--- a/src/stick_table.c
+++ b/src/stick_table.c
@@ -2075,12 +2075,10 @@ static enum act_return action_set_gpt0(struct act_rule *rule, struct proxy *px,
 	/* Store the sample in the required sc, and ignore errors. */
 	ptr = stktable_data_ptr(stkctr->table, ts, STKTABLE_DT_GPT0);
 	if (ptr) {
-		if (!rule->arg.gpt.expr) {
+		if (!rule->arg.gpt.expr)
 			value = rule->arg.gpt.value;
-		}
-		else if (!stktable_fetch_expr(rule, px, sess, s, rule->arg.gpt.expr, &value)) {
+		else if (!stktable_fetch_expr(rule, px, sess, s, rule->arg.gpt.expr, &value))
 			return ACT_RET_CONT;
-		}
 
 		HA_RWLOCK_WRLOCK(STK_SESS_LOCK, &ts->lock);
 
@@ -2125,16 +2123,12 @@ static enum act_parse_ret parse_set_gpt0(const char **args, int *arg, struct pro
 		cmd_name++; /* jump the '(' */
 		rule->arg.gpt.sc = strtol(cmd_name, &error, 10); /* Convert stick table id. */
 		if (*error != ')') {
-			memprintf(err,
-			          "invalid stick table track ID '%s'. Expects sc-set-gpt0(<Track ID>)",
-			          args[*arg-1]);
+			memprintf(err, "invalid stick table track ID '%s'. Expects sc-set-gpt0(<Track ID>)", args[*arg-1]);
 			return ACT_RET_PRS_ERR;
 		}
 
 		if (rule->arg.gpt.sc >= ACT_ACTION_TRK_SCMAX) {
-			memprintf(err,
-			          "invalid stick table track ID '%s'. The max allowed ID is %d",
-			          args[*arg-1], ACT_ACTION_TRK_SCMAX-1);
+			memprintf(err, "invalid stick table track ID '%s'. The max allowed ID is %d", args[*arg-1], ACT_ACTION_TRK_SCMAX-1);
 			return ACT_RET_PRS_ERR;
 		}
 	}
@@ -2154,14 +2148,11 @@ static enum act_parse_ret parse_set_gpt0(const char **args, int *arg, struct pro
 		case ACT_F_HTTP_REQ:    smp_val = SMP_VAL_FE_HRQ_HDR; break;
 		case ACT_F_HTTP_RES:    smp_val = SMP_VAL_BE_HRS_HDR; break;
 		default:
-			memprintf(err,
-			          "internal error, unexpected rule->from=%d, please report this bug!",
-			          rule->from);
+			memprintf(err, "internal error, unexpected rule->from=%d, please report this bug!", rule->from);
 			return ACT_RET_PRS_ERR;
 		}
 		if (!(rule->arg.gpt.expr->fetch->val & smp_val)) {
-			memprintf(err,
-			          "fetch method '%s' extracts information from '%s', none of which is available here",
+			memprintf(err, "fetch method '%s' extracts information from '%s', none of which is available here",
 			          args[*arg-1], sample_src_names(rule->arg.gpt.expr->fetch->use));
 			free(rule->arg.gpt.expr);
 			return ACT_RET_PRS_ERR;


### PR DESCRIPTION
Allow the `sc-set-gpt0()` action to set GPT0 to a value dynamically evaluated from
its `<expr>` argument (in addition to the existing static `<int>` alternative).

Hello HAProxy team!

While working on a use-case we have at hand, we ended up desperately needing the ability to set GPT0 from a dynamic value. This patch is mostly copy-paste from the `set-var()` action.

Looking forwards to your review and best,

Cédric