### PR TITLE
modify if condition redundant

### DIFF
--- a/src/mworker-prog.c
+++ b/src/mworker-prog.c
@@ -306,10 +306,8 @@ error:
 			int i;
 
 			for (i = 0; ext_child->command[i]; i++) {
-				if (ext_child->command[i]) {
-					free(ext_child->command[i]);
-					ext_child->command[i] = NULL;
-				}
+				free(ext_child->command[i]);
+				ext_child->command[i] = NULL;
 			}
 			free(ext_child->command);
 			ext_child->command = NULL;


### PR DESCRIPTION
Identical inner 'if' condition is always true (outer condition is 'ext_child->command[i]' and inner condition is 'ext_child->command[i]')