### PR TITLE
Add missing string length for lua sticktable lookup

### DIFF
--- a/src/hlua_fcn.c
+++ b/src/hlua_fcn.c
@@ -612,6 +612,7 @@ int hlua_stktable_lookup(lua_State *L)
 	smp.data.type = SMP_T_STR;
 	smp.flags = SMP_F_CONST;
 	smp.data.u.str.area = (char *)luaL_checkstring(L, 2);
+	smp.data.u.str.data = strlen(smp.data.u.str.area);
 
 	skey = smp_to_stkey(&smp, t);
 	if (!skey) {


### PR DESCRIPTION
Consider moving this to smp_to_stkey - or at least adding a:

```if ( smp->data.u.str.data == 0 ) { static_table_key.key_len = strlen(smp->data.u.str.key); }```

equivalent to smp_to_stkey