### PR TITLE
Updating Documentation for Hashing

### DIFF
--- a/doc/internals/hashing.txt
+++ b/doc/internals/hashing.txt
@@ -79,5 +79,5 @@ algorithms that are better for different inputs. Avalanche is not always
 applicable and may result in less smooth distribution.
 
 References:
-Mixing Functions/Avalanche: http://home.comcast.net/~bretm/hash/3.html
+Hash Functions (previously Mixing Functions/Avalanche): https://papa.bretmulvey.com/post/124027987928/hash-functions
 Hash Functions: http://www.cse.yorku.ca/~oz/hash.html


### PR DESCRIPTION
Bret Mulvey, the author of the article cited in this pulication has migrated his work to papa.bretmulvey.com. I was able to view an archival version of Bret M.'s original post (http://home.comcast.net/~bretm/hash/3.html) and have validated that this is the same paper that is originally cited.