### PR TITLE
Unindent non-code sentences in the protobuf example

### DIFF
--- a/doc/configuration.txt
+++ b/doc/configuration.txt
@@ -15440,30 +15440,30 @@ ungrpc(<field_number>,[<field_type>])
       PPoint hi = 49;
     }
 
-    let's say a body request is made of a "Rectangle" object value (two PPoint
-    protocol buffers messages), the four protocol buffers fields could be
-    extracted with these "ungrpc" directives:
+  let's say a body request is made of a "Rectangle" object value (two PPoint
+  protocol buffers messages), the four protocol buffers fields could be
+  extracted with these "ungrpc" directives:
 
     req.body,ungrpc(48.59.1,int32) # "latitude" of "lo" first PPoint
     req.body,ungrpc(48.59.2,int32) # "longitude" of "lo" first PPoint
     req.body,ungrpc(49.59.1,int32) # "latitude" of "hi" second PPoint
     req.body,ungrpc(49.59.2,int32) # "longitude" of "hi" second PPoint
 
-    We could also extract the intermediary 48.59 field as a binary sample as follows:
+  We could also extract the intermediary 48.59 field as a binary sample as follows:
 
     req.body,ungrpc(48.59)
 
-    As a gRPC message is always made of a gRPC header followed by protocol buffers
-    messages, in the previous example the "latitude" of "lo" first PPoint
-    could be extracted with these equivalent directives:
+  As a gRPC message is always made of a gRPC header followed by protocol buffers
+  messages, in the previous example the "latitude" of "lo" first PPoint
+  could be extracted with these equivalent directives:
 
     req.body,ungrpc(48.59),protobuf(1,int32)
     req.body,ungrpc(48),protobuf(59.1,int32)
     req.body,ungrpc(48),protobuf(59),protobuf(1,int32)
 
-    Note that the first convert must be "ungrpc", the remaining ones must be
-    "protobuf" and only the last one may have or not a second argument to
-    interpret the previous binary sample.
+  Note that the first convert must be "ungrpc", the remaining ones must be
+  "protobuf" and only the last one may have or not a second argument to
+  interpret the previous binary sample.
 
 
 unset-var(<var name>)


### PR DESCRIPTION
Unindent to make the explanation go back to text from code formatted example in tyhe HTMLized version. Still it's not perfect since these are not haproxy examples but protobuf config, but... way better.