### PR TITLE
DOC: Update docs / comments to be inclusive of all gender identities

### DIFF
--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -1002,7 +1002,7 @@ you notice you're already practising some of them:
     and removed in a future version.
 
   - send a new patch iteration without taking *all* comments from previous
-    review into consideration, so that the reviewer discovers he/she has to do
+    review into consideration, so that the reviewer discovers they have to do
     the exact same work again.
 
   - "hijack" an existing thread to discuss something different or promote your

--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -279,7 +279,7 @@ do not think about them anymore after a few patches.
      error handling roughly represents half of the code, and that's about 3/4 of
      the configuration parser. Take the time to do something you're proud of. A
      good rule of thumb is to keep in mind that your code talks to a human and
-     tries to teach him/her how to proceed. It must then speak like a human.
+     tries to teach them how to proceed. It must then speak like a human.
 
    - The third most important level is the code and its accompanying comments,
      including the commit message which is a complement to your code and

--- a/doc/architecture.txt
+++ b/doc/architecture.txt
@@ -49,7 +49,7 @@ load across the new boxes.
 
 Config on haproxy (LB1) :
 -------------------------
-       
+
     listen webfarm 192.168.1.1:80
        mode http
        balance roundrobin
@@ -59,7 +59,7 @@ Config on haproxy (LB1) :
        server webB 192.168.1.12:80 cookie B check
        server webC 192.168.1.13:80 cookie C check
        server webD 192.168.1.14:80 cookie D check
-       
+
 
 Description :
 -------------
@@ -165,7 +165,7 @@ precedence over load balancing :
        server webB 192.168.1.12:80 cookie B check
        server webC 192.168.1.13:80 cookie C check
        server webD 192.168.1.14:80 cookie D check
-       
+
 
 ==================================================================
 2. HTTP load-balancing with cookie prefixing and high availability
@@ -201,7 +201,7 @@ proxy to bind to the shared IP on Linux 2.4, you must enable it in /proc :
 
 
 Config on both proxies (LB1 and LB2) :
---------------------------------------       
+--------------------------------------
 
     listen webfarm 192.168.1.1:80
        mode http
@@ -214,7 +214,7 @@ Config on both proxies (LB1 and LB2) :
        server webB 192.168.1.12:80 cookie B check
        server webC 192.168.1.13:80 cookie C check
        server webD 192.168.1.14:80 cookie D check
-       
+
 
 Notes: the proxy will modify EVERY cookie sent by the client and the server,
 so it is important that it can access to ALL cookies in ALL requests for
@@ -338,7 +338,7 @@ which will also check that the services run fine on both proxies :
 
 Config on both proxies (LB1 and LB2) :
 --------------------------------------
-       
+
     listen webfarm 0.0.0.0:80
        mode http
        balance roundrobin
@@ -356,7 +356,7 @@ Config on both proxies (LB1 and LB2) :
 The "dontlognull" option is used to prevent the proxy from logging the health
 checks from the Alteon. If a session exchanges no data, then it will not be
 logged.
-       
+
 Config on the Alteon :
 ----------------------
 
@@ -419,7 +419,7 @@ than or equal to 1.1.32 or 1.2.6.
 
 Config on both proxies (LB1 and LB2) :
 --------------------------------------
-       
+
     listen tse-proxy
        bind :3389,:1494,:5900  # TSE, ICA and VNC at once.
        mode tcp
@@ -522,12 +522,12 @@ measures must be taken to ensure that inserted cookies will not be cached.
      +-----+      +---+ +---+ +---+ +---+    (___)
      apache         4 cheap web servers
      mod_ssl
-     haproxy 
+     haproxy
 
 
 Config on haproxy (LB1) :
 -------------------------
-       
+
     listen 127.0.0.1:8000
        mode http
        balance roundrobin
@@ -537,7 +537,7 @@ Config on haproxy (LB1) :
        server webB 192.168.1.12:80 cookie B check
        server webC 192.168.1.13:80 cookie C check
        server webD 192.168.1.14:80 cookie D check
-       
+
 
 Description :
 -------------
@@ -614,7 +614,7 @@ haproxy that connections from local host already have a valid header.
      | LB1 |      | A | | B | | C | | D |    (___)
      +-----+      +---+ +---+ +---+ +---+    (___)
      stunnel        4 cheap web servers
-     haproxy 
+     haproxy
 
 
 Config on stunnel (LB1) :
@@ -635,7 +635,7 @@ Config on stunnel (LB1) :
 
 Config on haproxy (LB1) :
 -------------------------
-       
+
     listen 192.168.1.1:80
        mode http
        balance roundrobin
@@ -680,7 +680,7 @@ file. The proxy will see the server as failed, and will not send it any new
 session, only the old ones if the "persist" option is used. Wait a bit then
 stop the server when it does not receive anymore connections.
 
-       
+
     listen 192.168.1.1:80
        mode http
        balance roundrobin
@@ -703,7 +703,7 @@ Description :
  - if a request does not contain a cookie, it will be forwarded to a valid
    server
  - if a request contains a cookie for a failed server, haproxy will insist
-   on trying to reach the server anyway, to let the user finish what he was
+   on trying to reach the server anyway, to let the user finish what they were
    doing. ("persist" option)
  - if the server is totally stopped, the connection will fail and the proxy
    will rebalance the client to another server ("redispatch")
@@ -739,7 +739,7 @@ A better solution which covers every situation is to use backup servers.
 Version 1.1.30 fixed a bug which prevented a backup server from sharing
 the same cookie as a standard server.
 
-       
+
     listen 192.168.1.1:80
        mode http
        balance roundrobin
@@ -798,7 +798,7 @@ once you see that the server does not receive any traffic, simply stop it :
   # /etc/init.d/httpd stop
 
 The associated backup server will in turn fail, and if any client still tries
-to access this particular server, he will be redispatched to any other valid
+to access this particular server, they will be redispatched to any other valid
 server because of the "redispatch" option.
 
 This method has an advantage : you never touch the proxy when doing server
@@ -986,7 +986,7 @@ The main constraints are :
     traffic to the second site. These proxies will be called "OP1".."OPXX"
     for "Office Proxy #XX".
 
-  
+
 5.3 Network diagram
 ===================
 
@@ -999,34 +999,34 @@ Note : offices 1 and 2 are on the same continent as site 1, while
         Office1         Office2                          Office3
          users           users                            users
 192.168  # # #   192.168 # # #                            # # #
-.1.0/24  | | |   .2.0/24 | | |             192.168.3.0/24 | | |	  
-  --+----+-+-+-   --+----+-+-+-                   ---+----+-+-+- 
+.1.0/24  | | |   .2.0/24 | | |             192.168.3.0/24 | | |
+  --+----+-+-+-   --+----+-+-+-                   ---+----+-+-+-
     |      | .1     |      | .1                      |      | .1
     |    +-+-+      |    +-+-+                       |    +-+-+
     |    |OP1|      |    |OP2|                       |    |OP3|  ...
   ,-:-.  +---+    ,-:-.  +---+                     ,-:-.  +---+
- (  X  )         (  X  )                          (  X  )        
-  `-:-'           `-:-'             ,---.          `-:-'         
+ (  X  )         (  X  )                          (  X  )
+  `-:-'           `-:-'             ,---.          `-:-'
   --+---------------+------+----~~~(  X  )~~~~-------+---------+-
-                           |        `---'                      |    
-                           |                                   |    
-                 +---+   ,-:-.                       +---+   ,-:-.  
+                           |        `---'                      |
+                           |                                   |
+                 +---+   ,-:-.                       +---+   ,-:-.
                  |SD1|  (  X  )                      |SD2|  (  X  )
    ( SITE 1 )    +-+-+   `-:-'         ( SITE 2 )    +-+-+   `-:-'
-                   |.1     |                           |.1     |    
-   10.1.1.0/24     |       |     ,---. 10.2.1.0/24     |       |    
+                   |.1     |                           |.1     |
+   10.1.1.0/24     |       |     ,---. 10.2.1.0/24     |       |
         -+-+-+-+-+-+-+-----+-+--(  X  )------+-+-+-+-+-+-+-----+-+--
          | | | | |   |       |   `---'       | | | | |   |       |
       ...# # # # #   |.11    |.12         ...# # # # #   |.11    |.12
-          Site 1   +-+--+  +-+--+              Site 2  +-+--+  +-+--+   
-          Local    |S1L1|  |S1L2|              Local   |S2L1|  |S2L2|   
-          users    +-+--+  +--+-+              users   +-+--+  +--+-+   
-                     |        |	                         |        |     
-   10.1.2.0/24    -+-+-+--+--++--      10.2.2.0/24    -+-+-+--+--++--   
+          Site 1   +-+--+  +-+--+              Site 2  +-+--+  +-+--+
+          Local    |S1L1|  |S1L2|              Local   |S2L1|  |S2L2|
+          users    +-+--+  +--+-+              users   +-+--+  +--+-+
+                     |        |	                         |        |
+   10.1.2.0/24    -+-+-+--+--++--      10.2.2.0/24    -+-+-+--+--++--
                    |.1       |.4                       |.1       |.4
-                 +-+-+     +-+-+                     +-+-+     +-+-+    
-                 |W11| ~~~ |W14|                     |W21| ~~~ |W24|    
-                 +---+     +---+                     +---+     +---+    
+                 +-+-+     +-+-+                     +-+-+     +-+-+
+                 |W11| ~~~ |W14|                     |W21| ~~~ |W24|
+                 +---+     +---+                     +---+     +---+
               4 application servers               4 application servers
                     on site 1                           on site 2
 
@@ -1359,7 +1359,7 @@ very fast response times.
 
 Config on haproxy (LB1) :
 -------------------------
-       
+
     listen appfarm 192.168.1.1:80
        mode http
        maxconn 10000
@@ -1430,7 +1430,7 @@ normal loads, and availability under very high loads.
 
 Example :
 ---------
-       
+
     listen appfarm 192.168.1.1:80
        mode http
        maxconn 10000
@@ -1444,5 +1444,3 @@ Example :
        server railsB 192.168.1.12:80 minconn 4 maxconn 12 check
        server railsC 192.168.1.13:80 minconn 4 maxconn 12 check
        contimeout 60000
-
-

--- a/doc/coding-style.txt
+++ b/doc/coding-style.txt
@@ -56,7 +56,7 @@ or a condition) :
   | main(int argc, char **argv)
   | {
   |         int i;
-  | 
+  |
   |         if (argc < 2)
   |                 exit(1);
   | }
@@ -986,7 +986,7 @@ Wrong :
 It is very common for macros to do the wrong thing when used in a way their
 author did not have in mind. For this reason, macros must always be named with
 uppercase letters only. This is the only way to catch the developer's eye when
-using them, so that he double-checks whether he's taking risks or not. First,
+using them, so that they double-check whether they are taking a risk or not. First,
 macros must never ever be terminated by a semi-colon, or they will close the
 wrong block once in a while. For instance, the following will cause a build
 error before the "else" due to the double semi-colon :
@@ -1261,4 +1261,3 @@ Example :
   | #endif
   |         return result;
   | }
-

--- a/doc/configuration.txt
+++ b/doc/configuration.txt
@@ -9868,7 +9868,7 @@ stats refresh <delay>
   This statement is useful on monitoring displays with a permanent page
   reporting the load balancer's activity. When set, the HTML report page will
   include a link "refresh"/"stop refresh" so that the user can select whether
-  he wants automatic refresh of the page or not.
+  they want automatic refresh of the page or not.
 
   Though this statement alone is enough to enable statistics reporting, it is
   recommended to set all other settings in order to avoid relying on default

--- a/doc/gpl.txt
+++ b/doc/gpl.txt
@@ -219,7 +219,7 @@ integrity of the free software distribution system, which is
 implemented by public license practices.  Many people have made
 generous contributions to the wide range of software distributed
 through that system in reliance on consistent application of that
-system; it is up to the author/donor to decide if he or she is willing
+system; it is up to the author/donor to decide if they are willing
 to distribute software through any other system and a licensee cannot
 impose that choice.
 

--- a/doc/lgpl.txt
+++ b/doc/lgpl.txt
@@ -146,7 +146,7 @@ such a program is covered only if its contents constitute a work based
 on the Library (independent of the use of the Library in a tool for
 writing it).  Whether that is true depends on what the Library does
 and what the program that uses the Library does.
-  
+
   1. You may copy and distribute verbatim copies of the Library's
 complete source code as you receive it, in any medium, provided that
 you conspicuously and appropriately publish on each copy an
@@ -395,7 +395,7 @@ integrity of the free software distribution system which is
 implemented by public license practices.  Many people have made
 generous contributions to the wide range of software distributed
 through that system in reliance on consistent application of that
-system; it is up to the author/donor to decide if he or she is willing
+system; it is up to the author/donor to decide if they are willing
 to distribute software through any other system and a licensee cannot
 impose that choice.
 
@@ -500,5 +500,3 @@ necessary.  Here is a sample; alter the names:
   Ty Coon, President of Vice
 
 That's all there is to it!
-
-

--- a/doc/lua.txt
+++ b/doc/lua.txt
@@ -381,7 +381,7 @@ In most cases, an HAProxy Lua object needs some private data. These are always
 set in the index [0] of the array. The metatable entry "__tostring" returns the
 object name.
 
-The Lua developer can add entries to the HAProxy object. He just works carefully
+The Lua developer can add entries to the HAProxy object. They just works carefully
 and prevent to modify the index [0].
 
 Common HAproxy objects are:

--- a/doc/management.txt
+++ b/doc/management.txt
@@ -467,7 +467,7 @@ To understand better how these signals are used, it is important to understand
 the whole restart mechanism.
 
 First, an existing haproxy process is running. The administrator uses a system
-specific command such as "/etc/init.d/haproxy reload" to indicate he wants to
+specific command such as "/etc/init.d/haproxy reload" to indicate they want to
 take the new configuration file into effect. What happens then is the following.
 First, the service script (/etc/init.d/haproxy or equivalent) will verify that
 the configuration file parses correctly using "haproxy -c". After that it will
@@ -3396,4 +3396,3 @@ A safe configuration will have :
     group allowed to access the CLI so that nobody may access it :
 
       stats socket /var/run/haproxy.stat uid hatop gid hatop mode 600
-

--- a/doc/peers-v2.0.txt
+++ b/doc/peers-v2.0.txt
@@ -250,7 +250,7 @@ Encoded Remote Table Id | Update Id
 Remote Table Id is the numeric identifier of the table on the remote side.
 Update Id is the id of the last update locally committed.
 
-If a re-connection occurred, the sender should know he will have to restart the push of updates from this point.
+If a re-connection occurred, the sender should know they will have to restart the push of updates from this point.
 
 III) Initial full resync process.
 
@@ -261,7 +261,7 @@ An old soft-stopped process will close all established sessions with remote peer
 local process to push all known ending with a Resync Finished Message or a Resync Partial Message (if it it does not consider itself as full updated).
 
 A new process will wait for a an incoming connection from a local process during 5 seconds. It will learn the updates from this
-process until he will receive a Resync Finished Message or a Resync Partial Message. If it receive a  Resync Finished Message it will consider itself
+process until it receives a Resync Finished Message or a Resync Partial Message. If it receive a  Resync Finished Message it will consider itself
 as fully updated and stops to ask for resync. If it receive a Resync Partial Message it will wait once again for 5 seconds for an other incoming connection from a local process.
 Same thing if the session was broken before receiving any "Resync Partial Message" or "Resync Finished Message".
 
@@ -284,5 +284,3 @@ If it receives a Resync Partial Message, the current peer will be flagged to any
 If the session is broken before receiving any of these messages any other connected peer will be randomly chosen for a resync request (5s).
 
 If the timeout expire, the process will consider itself as fully updated
-
-

--- a/doc/proxy-protocol.txt
+++ b/doc/proxy-protocol.txt
@@ -529,8 +529,8 @@ bytes specified by the length.
             uint8_t value[0];
         };
 
-A receiver may choose to skip over and ignore the TLVs he is not interested in
-or he does not understand. Senders can generate the TLVs only for
+A receiver may choose to skip over and ignore the TLVs it is not interested in
+or it does not understand. Senders can generate the TLVs only for
 the information they choose to publish.
 
 The following types have already been registered for the <type> field :
@@ -854,8 +854,8 @@ time, it ensures that improperly configured servers are quickly detected.
 Implementers should be very careful about not trying to automatically detect
 whether they have to decode the header or not, but rather they must only rely
 on a configuration parameter. Indeed, if the opportunity is left to a normal
-client to use the protocol, he will be able to hide his activities or make them
-appear as coming from someone else. However, accepting the header only from a
+client to use the protocol, it will be able to hide it's activities or make them
+appear as coming from somewhere else. However, accepting the header only from a
 number of known sources should be safe.
 
 

--- a/src/cli.c
+++ b/src/cli.c
@@ -1725,7 +1725,7 @@ static int _getsocks(char **args, char *payload, struct appctx *appctx, void *pr
 	memset(&msghdr, 0, sizeof(msghdr));
 	/*
 	 * First, calculates the total number of FD, so that we can let
-	 * the caller know how much he should expects.
+	 * the caller know how much it should expect.
 	 */
 	px = proxies_list;
 	while (px) {

--- a/src/haproxy.c
+++ b/src/haproxy.c
@@ -3370,8 +3370,8 @@ int main(int argc, char **argv)
 		exit(1);
 	}
 
-	/* If the user is not root, we'll still let him try the configuration
-	 * but we inform him that unexpected behaviour may occur.
+	/* If the user is not root, we'll still let them try the configuration
+	 * but we inform them that unexpected behaviour may occur.
 	 */
 	if ((global.last_checks & LSTCHK_NETADM) && getuid())
 		ha_warning("[%s.main()] Some options which require full privileges"


### PR DESCRIPTION
To promote an inclusive environment for all communities, this PR converts all references of gender specific pronouns, e.g "he" or "she", into the third-person pronoun "they" as it is inclusive of all people. Furthermore, documentation / comments should use singular "they" when referring to a generic person whose gender is unknown or irrelevant to the context.

Also, remove some trailing whitespaces from the files modified. 