### PR TITLE
hpack-tbl-t.h uses VAR_ARRAY and requires compiler.h to be included

### DIFF
--- a/include/haproxy/hpack-tbl-t.h
+++ b/include/haproxy/hpack-tbl-t.h
@@ -28,6 +28,7 @@
 #define _HAPROXY_HPACK_TBL_T_H
 
 #include <inttypes.h>
+#include "compiler.h"
 
 /* Dynamic Headers Table, usable for tables up to 4GB long and values of 64kB-1.
  * The model can be improved by using offsets relative to the table entry's end


### PR DESCRIPTION
This fixes building hpack from contrib, which failed because of the
undeclared VAR_ARRAY:

make -C contrib/hpack
...
cc -O2 -Wall -g -I../../include -fwrapv -fno-strict-aliasing   -c -o gen-enc.o gen-enc.c
In file included from gen-enc.c:18:
../../include/haproxy/hpack-tbl-t.h:105:23: error: 'VAR_ARRAY' undeclared here (not in a function)
  105 |  struct hpack_dte dte[VAR_ARRAY]; /* dynamic table entries */
...

Signed-off-by: Christian Ruppert <idl0r@qasl.de>