### PR TITLE
Fixed null pointer dereference in srv_cleanup_connections()

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -5300,9 +5300,9 @@ static void srv_cleanup_connections(struct server *srv)
 	/* check all threads starting with ours */
 	for (i = tid;;) {
 		did_remove = 0;
-		if (srv_migrate_conns_to_remove(&srv->idle_conns[i], &idle_conns[i].toremove_conns, -1) > 0)
+		if (srv->idle_conns && srv_migrate_conns_to_remove(&srv->idle_conns[i], &idle_conns[i].toremove_conns, -1) > 0)
 			did_remove = 1;
-		if (srv_migrate_conns_to_remove(&srv->safe_conns[i], &idle_conns[i].toremove_conns, -1) > 0)
+		if (srv->safe_conns && srv_migrate_conns_to_remove(&srv->safe_conns[i], &idle_conns[i].toremove_conns, -1) > 0)
 			did_remove = 1;
 		if (did_remove)
 			task_wakeup(idle_conns[i].cleanup_task, TASK_WOKEN_OTHER);


### PR DESCRIPTION
haproxy_srv_cleanup_connections_crash.cfg causes a null pointer dereference in srv_cleanup_connections . Configuration file works in 2.0.19  branch but crashes in all subsequent versions including the dev branch. I did not track down the cause, I just added the null pointer check to stop the crashing.

Crash can be reproduced with the following command:
./haproxy -c -f haproxy_srv_cleanup_connections_crash.cfg 

haproxy_srv_cleanup_connections_crash.cfg  can be grabbed from the gist below:
https://gist.github.com/peterska/769f41562f6b045df59df2294b2c20f0#file-haproxy_srv_cleanup_connections_crash-cfg

configuration file has been edited enough to cause the crash while removing all references to certificates and CA authorities. It is not a production config file.