### PR TITLE
proto_tcp.c: fix printing of muliple setsockopt errors

### DIFF
--- a/src/proto_tcp.c
+++ b/src/proto_tcp.c
@@ -594,7 +594,7 @@ int tcp_bind_listener(struct listener *listener, char *errmsg, int errlen)
 {
 	int fd, err;
 	int ready;
-	char *msg = NULL;
+	struct buffer *msg = alloc_trash_chunk();
 
 	err = ERR_NONE;
 
@@ -606,7 +606,7 @@ int tcp_bind_listener(struct listener *listener, char *errmsg, int errlen)
 		return ERR_NONE; /* already bound */
 
 	if (!(listener->rx.flags & RX_F_BOUND)) {
-		msg = "receiving socket not bound";
+		chunk_appendf(msg, "\nreceiving socket not bound");
 		goto tcp_return;
 	}
 
@@ -630,7 +630,7 @@ int tcp_bind_listener(struct listener *listener, char *errmsg, int errlen)
 	if (listener->maxseg > 0) {
 		if (setsockopt(fd, IPPROTO_TCP, TCP_MAXSEG,
 			       &listener->maxseg, sizeof(listener->maxseg)) == -1) {
-			msg = "cannot set MSS";
+			chunk_appendf(msg, "\ncannot set MSS");
 			err |= ERR_WARN;
 		}
 	} else {
@@ -648,7 +648,7 @@ int tcp_bind_listener(struct listener *listener, char *errmsg, int errlen)
 		if (defaultmss > 0 &&
 		    tmpmaxseg != defaultmss &&
 		    setsockopt(fd, IPPROTO_TCP, TCP_MAXSEG, &defaultmss, sizeof(defaultmss)) == -1) {
-			msg = "cannot set MSS";
+			chunk_appendf(msg, "\ncannot set MSS");
 			err |= ERR_WARN;
 		}
 	}
@@ -657,7 +657,7 @@ int tcp_bind_listener(struct listener *listener, char *errmsg, int errlen)
 	if (listener->tcp_ut) {
 		if (setsockopt(fd, IPPROTO_TCP, TCP_USER_TIMEOUT,
 			       &listener->tcp_ut, sizeof(listener->tcp_ut)) == -1) {
-			msg = "cannot set TCP User Timeout";
+			chunk_appendf(msg, "\ncannot set TCP User Timeout");
 			err |= ERR_WARN;
 		}
 	} else
@@ -669,7 +669,7 @@ int tcp_bind_listener(struct listener *listener, char *errmsg, int errlen)
 		/* defer accept by up to one second */
 		int accept_delay = 1;
 		if (setsockopt(fd, IPPROTO_TCP, TCP_DEFER_ACCEPT, &accept_delay, sizeof(accept_delay)) == -1) {
-			msg = "cannot enable DEFER_ACCEPT";
+			chunk_appendf(msg, "\ncannot enable DEFER_ACCEPT");
 			err |= ERR_WARN;
 		}
 	} else
@@ -681,7 +681,7 @@ int tcp_bind_listener(struct listener *listener, char *errmsg, int errlen)
 		/* TFO needs a queue length, let's use the configured backlog */
 		int qlen = listener_backlog(listener);
 		if (setsockopt(fd, IPPROTO_TCP, TCP_FASTOPEN, &qlen, sizeof(qlen)) == -1) {
-			msg = "cannot enable TCP_FASTOPEN";
+			chunk_appendf(msg, "\ncannot enable TCP_FASTOPEN");
 			err |= ERR_WARN;
 		}
 	} else {
@@ -695,7 +695,7 @@ int tcp_bind_listener(struct listener *listener, char *errmsg, int errlen)
 		    qlen != 0) {
 			if (setsockopt(fd, IPPROTO_TCP, TCP_FASTOPEN, &zero,
 			    sizeof(zero)) == -1) {
-				msg = "cannot disable TCP_FASTOPEN";
+				chunk_appendf(msg, "\ncannot disable TCP_FASTOPEN");
 				err |= ERR_WARN;
 			}
 		}
@@ -707,7 +707,7 @@ int tcp_bind_listener(struct listener *listener, char *errmsg, int errlen)
 	if (!ready && /* only listen if not already done by external process */
 	    listen(fd, listener_backlog(listener)) == -1) {
 		err |= ERR_RETRYABLE | ERR_ALERT;
-		msg = "cannot listen to socket";
+		chunk_appendf(msg, "\ncannot listen to socket");
 		goto tcp_close_return;
 	}
 
@@ -723,14 +723,18 @@ int tcp_bind_listener(struct listener *listener, char *errmsg, int errlen)
 	goto tcp_return;
 
  tcp_close_return:
+	free_trash_chunk(msg);
+	msg = NULL;
 	close(fd);
  tcp_return:
 	if (msg && errlen) {
 		char pn[INET6_ADDRSTRLEN];
 
 		addr_to_str(&listener->rx.addr, pn, sizeof(pn));
-		snprintf(errmsg, errlen, "%s [%s:%d]", msg, pn, get_host_port(&listener->rx.addr));
+		snprintf(errmsg, errlen, "%s\nfor [%s:%d]", msg->area, pn, get_host_port(&listener->rx.addr));
 	}
+	free_trash_chunk(msg);
+	msg = NULL;
 	return err;
 }
 


### PR DESCRIPTION
Attached patch is an attempt to fix the output of multiple setsockopt() warnings. Currently only the latest warning is printed because msg is overwritten with each new failed setsockopt() call.

Signed-off-by: Bjoern Jacke <bjacke@samba.org>

There is at least one thing left, which should be fixed somehow: if many setsockopt() calls fail, then errlen exceeds and the warning message is truncated, I've seen this happend actually. This is a TODO for someone, who knows the code better :-)