### PR TITLE
lua: add lua 5.4 support and prioritize it

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -295,9 +295,9 @@ Lua is an embedded programming language supported by HAProxy to provide more
 advanced scripting capabilities. Only versions 5.3 and above are supported.
 In order to enable Lua support, please specify "USE_LUA=1" on the command line.
 Some systems provide this library under various names to avoid conflicts with
-previous versions. By default, HAProxy looks for "lua5.3", "lua53", "lua". If
-your system uses a different naming, you may need to set the library name in
-the "LUA_LIB_NAME" variable.
+previous versions. By default, HAProxy looks for "lua5.4", "lua54","lua5.3",
+"lua53","lua". If your system uses a different naming, you may need to set
+the library name in the "LUA_LIB_NAME" variable.
 
 If Lua is not provided on your system, it can be very simply built locally. It
 can be downloaded from https://www.lua.org/, extracted and built, for example :

--- a/Makefile
+++ b/Makefile
@@ -589,11 +589,11 @@ OPTIONS_CFLAGS  += $(if $(LUA_INC),-I$(LUA_INC))
 LUA_LD_FLAGS := -Wl,$(if $(EXPORT_SYMBOL),$(EXPORT_SYMBOL),--export-dynamic) $(if $(LUA_LIB),-L$(LUA_LIB))
 ifeq ($(LUA_LIB_NAME),)
 # Try to automatically detect the Lua library
-LUA_LIB_NAME := $(firstword $(foreach lib,lua5.3 lua53 lua,$(call check_lua_lib,$(lib),$(LUA_LD_FLAGS))))
+LUA_LIB_NAME := $(firstword $(foreach lib,lua5.4 lua54 lua5.3 lua53 lua,$(call check_lua_lib,$(lib),$(LUA_LD_FLAGS))))
 ifeq ($(LUA_LIB_NAME),)
-$(error unable to automatically detect the Lua library name, you can enforce its name with LUA_LIB_NAME=<name> (where <name> can be lua5.3, lua53, lua, ...))
+$(error unable to automatically detect the Lua library name, you can enforce its name with LUA_LIB_NAME=<name> (where <name> can be lua5.4, lua54, lua5.3, lua53, lua, ...))
 endif
-LUA_INC := $(firstword $(foreach lib,lua5.3 lua53 lua,$(call check_lua_inc,$(lib),"/usr/include/")))
+LUA_INC := $(firstword $(foreach lib,lua5.4 lua54 lua5.3 lua53 lua,$(call check_lua_inc,$(lib),"/usr/include/")))
 ifneq ($(LUA_INC),)
 OPTIONS_CFLAGS  += -I$(LUA_INC)
 endif


### PR DESCRIPTION
Build succeeded:
https://build.opensuse.org/build/home:gmbr3:Lua/openSUSE_Tumbleweed/x86_64/haproxy/_log