### PR TITLE
Correct example reload command in the document

### DIFF
--- a/doc/management.txt
+++ b/doc/management.txt
@@ -3296,7 +3296,7 @@ has at least "operator" or "admin" privileges.
 
 Example:
 
-  $ echo "reload" | socat /var/run/haproxy-master.sock
+  $ echo "reload" | socat /var/run/haproxy-master.sock stdin
 
 Note that a reload will close the connection to the master CLI.
 


### PR DESCRIPTION
Current example is:

`echo "reload" | socat /var/run/haproxy-master.sock`

it will cause socat error:

`exactly 2 addresses required (there are 1); use option "-h" for help`

Correct working command is:

`echo "reload" | socat /var/run/haproxy-master.sock stdin`