### PR TITLE
Using standard 'OOM' instead of 'Out of Memory'

### DIFF
--- a/addons/ot/src/conf.c
+++ b/addons/ot/src/conf.c
@@ -69,7 +69,7 @@ static void *flt_ot_conf_hdr_init(size_t size, const char *id, int linenum, stru
 		if (head != NULL)
 			LIST_APPEND(head, &(retptr->list));
 	} else {
-		FLT_OT_ERR("out of memory");
+		FLT_OT_ERR("OOM");
 	}
 
 	FLT_OT_RETURN(retptr);

--- a/addons/ot/src/group.c
+++ b/addons/ot/src/group.c
@@ -278,7 +278,7 @@ static enum act_parse_ret flt_ot_group_parse(const char **args, int *cur_arg, st
 	/* Copy the OpenTracing filter id. */
 	rule->arg.act.p[FLT_OT_ARG_FILTER_ID] = FLT_OT_STRDUP(args[*cur_arg]);
 	if (rule->arg.act.p[FLT_OT_ARG_FILTER_ID] == NULL) {
-		FLT_OT_ERR("%s : out of memory", args[*cur_arg]);
+		FLT_OT_ERR("%s : OOM", args[*cur_arg]);
 
 		FLT_OT_RETURN(ACT_RET_PRS_ERR);
 	}
@@ -286,7 +286,7 @@ static enum act_parse_ret flt_ot_group_parse(const char **args, int *cur_arg, st
 	/* Copy the OpenTracing group id. */
 	rule->arg.act.p[FLT_OT_ARG_GROUP_ID] = FLT_OT_STRDUP(args[*cur_arg + 1]);
 	if (rule->arg.act.p[FLT_OT_ARG_GROUP_ID] == NULL) {
-		FLT_OT_ERR("%s : out of memory", args[*cur_arg + 1]);
+		FLT_OT_ERR("%s : OOM", args[*cur_arg + 1]);
 
 		FLT_OT_FREE_CLEAR(rule->arg.act.p[FLT_OT_ARG_FILTER_ID]);
 

--- a/addons/ot/src/parser.c
+++ b/addons/ot/src/parser.c
@@ -62,7 +62,7 @@ static int flt_ot_parse_strdup(char **ptr, const char *str, char **err, const ch
 
 	*ptr = FLT_OT_STRDUP(str);
 	if (*ptr == NULL) {
-		FLT_OT_PARSE_ERR(err, "'%s' : out of memory", err_msg);
+		FLT_OT_PARSE_ERR(err, "'%s' : OOM", err_msg);
 
 		retval |= ERR_ABORT | ERR_ALERT;
 	}
@@ -316,7 +316,7 @@ static int flt_ot_parse_cfg_sample(const char *file, int linenum, char **args, s
 
 	sample = flt_ot_conf_sample_init(args, linenum, head, err);
 	if (sample == NULL)
-		FLT_OT_PARSE_ERR(err, "'%s' : out of memory", args[0]);
+		FLT_OT_PARSE_ERR(err, "'%s' : OOM", args[0]);
 
 	if (!(retval & ERR_CODE)) {
 		flt_ot_current_config->proxy->conf.args.ctx  = ARGC_OT;
@@ -1157,7 +1157,7 @@ static int flt_ot_parse(char **args, int *cur_arg, struct proxy *px, struct flt_
 
 	conf = flt_ot_conf_init(px);
 	if (conf == NULL) {
-		FLT_OT_PARSE_ERR(err, "'%s' : out of memory", args[*cur_arg]);
+		FLT_OT_PARSE_ERR(err, "'%s' : OOM", args[*cur_arg]);
 
 		FLT_OT_RETURN(retval);
 	}

--- a/addons/ot/src/pool.c
+++ b/addons/ot/src/pool.c
@@ -51,7 +51,7 @@ void *flt_ot_pool_alloc(struct pool_head *pool, size_t size, bool flag_clear, ch
 	}
 
 	if (retptr == NULL)
-		FLT_OT_ERR("out of memory");
+		FLT_OT_ERR("OOM");
 	else if (flag_clear)
 		(void)memset(retptr, 0, size);
 
@@ -95,7 +95,7 @@ void *flt_ot_pool_strndup(struct pool_head *pool, const char *s, size_t size, ch
 	if (retptr != NULL)
 		FLT_OT_DBG(2, "POOL_STRNDUP: %s:%d(%p %zu)", __func__, __LINE__, retptr, FLT_OT_DEREF(pool, size, size));
 	else
-		FLT_OT_ERR("out of memory");
+		FLT_OT_ERR("OOM");
 
 	FLT_OT_RETURN(retptr);
 }
@@ -171,7 +171,7 @@ struct buffer *flt_ot_trash_alloc(bool flag_clear, char **err)
 #endif
 
 	if (retptr == NULL)
-		FLT_OT_ERR("out of memory");
+		FLT_OT_ERR("OOM");
 	else if (flag_clear)
 		(void)memset(retptr->area, 0, retptr->size);
 

--- a/addons/ot/src/util.c
+++ b/addons/ot/src/util.c
@@ -333,7 +333,7 @@ ssize_t flt_ot_chunk_add(struct buffer *chk, const void *src, size_t n, char **e
 		chunk_init(chk, FLT_OT_CALLOC(1, global.tune.bufsize), global.tune.bufsize);
 
 	if (chk->area == NULL) {
-		FLT_OT_ERR("out of memory");
+		FLT_OT_ERR("OOM");
 
 		FLT_OT_RETURN(-1);
 	}
@@ -669,7 +669,7 @@ int flt_ot_sample_to_value(const char *key, const struct sample_data *data, stru
 		value->value.string_value = FLT_OT_MALLOC(global.tune.bufsize);
 
 		if (value->value.string_value == NULL)
-			FLT_OT_ERR("out of memory");
+			FLT_OT_ERR("OOM");
 		else
 			retval = flt_ot_sample_to_str(data, (char *)value->value.string_value, global.tune.bufsize, err);
 	}
@@ -747,7 +747,7 @@ int flt_ot_sample_add(struct stream *s, uint dir, struct flt_ot_conf_sample *sam
 			if (buffer.area == NULL) {
 				chunk_init(&buffer, FLT_OT_CALLOC(1, global.tune.bufsize), global.tune.bufsize);
 				if (buffer.area == NULL) {
-					FLT_OT_ERR("out of memory");
+					FLT_OT_ERR("OOM");
 
 					retval = FLT_OT_RET_ERROR;
 
@@ -789,12 +789,12 @@ int flt_ot_sample_add(struct stream *s, uint dir, struct flt_ot_conf_sample *sam
 			data->baggage = otc_text_map_new(NULL, FLT_OT_MAXBAGGAGES);
 
 		if (data->baggage == NULL) {
-			FLT_OT_ERR("out of memory");
+			FLT_OT_ERR("OOM");
 
 			retval = FLT_OT_RET_ERROR;
 		}
 		else if (otc_text_map_add(data->baggage, sample->key, 0, value.value.string_value, 0, 0) == -1) {
-			FLT_OT_ERR("out of memory");
+			FLT_OT_ERR("OOM");
 
 			retval = FLT_OT_RET_ERROR;
 		}

--- a/doc/internals/filters.txt
+++ b/doc/internals/filters.txt
@@ -391,7 +391,7 @@ filter line :
         /* Allocate the internal configuration used by the filter */
         my_conf = calloc(1, sizeof(*my_conf));
         if (!my_conf) {
-            memprintf(err, "%s : out of memory", args[*cur_arg]);
+            memprintf(err, "%s : OOM", args[*cur_arg]);
             return -1;
         }
         my_conf->proxy = px;
@@ -410,7 +410,7 @@ filter line :
                 }
                 my_conf->name = strdup(args[pos + 1]);
                 if (!my_conf->name) {
-                    memprintf(err, "%s : out of memory", args[*cur_arg]);
+                    memprintf(err, "%s : OOM", args[*cur_arg]);
                     goto error;
                 }
                 pos += 2;

--- a/src/acl.c
+++ b/src/acl.c
@@ -173,7 +173,7 @@ struct acl_expr *parse_acl_expr(const char **args, char **err, struct arg_list *
 		/* build new sample expression for this ACL */
 		smp = calloc(1, sizeof(*smp));
 		if (!smp) {
-			memprintf(err, "out of memory when parsing ACL expression");
+			memprintf(err, "OOM when parsing ACL expression");
 			goto out_return;
 		}
 		LIST_INIT(&(smp->conv_exprs));
@@ -321,7 +321,7 @@ struct acl_expr *parse_acl_expr(const char **args, char **err, struct arg_list *
 
 	expr = calloc(1, sizeof(*expr));
 	if (!expr) {
-		memprintf(err, "out of memory when parsing ACL expression");
+		memprintf(err, "OOM when parsing ACL expression");
 		goto out_free_smp;
 	}
 
@@ -709,12 +709,12 @@ struct acl *parse_acl(const char **args, struct list *known_acl, char **err, str
 	if (!cur_acl) {
 		name = strdup(args[0]);
 		if (!name) {
-			memprintf(err, "out of memory when parsing ACL");
+			memprintf(err, "OOM when parsing ACL");
 			goto out_free_acl_expr;
 		}
 		cur_acl = calloc(1, sizeof(*cur_acl));
 		if (cur_acl == NULL) {
-			memprintf(err, "out of memory when parsing ACL");
+			memprintf(err, "OOM when parsing ACL");
 			goto out_free_name;
 		}
 
@@ -808,13 +808,13 @@ static struct acl *find_acl_default(const char *acl_name, struct list *known_acl
 
 	name = strdup(acl_name);
 	if (!name) {
-		memprintf(err, "out of memory when building default ACL '%s'", acl_name);
+		memprintf(err, "OOM when building default ACL '%s'", acl_name);
 		goto out_free_acl_expr;
 	}
 
 	cur_acl = calloc(1, sizeof(*cur_acl));
 	if (cur_acl == NULL) {
-		memprintf(err, "out of memory when building default ACL '%s'", acl_name);
+		memprintf(err, "OOM when building default ACL '%s'", acl_name);
 		goto out_free_name;
 	}
 
@@ -875,7 +875,7 @@ struct acl_cond *parse_acl_cond(const char **args, struct list *known_acl,
 
 	cond = calloc(1, sizeof(*cond));
 	if (cond == NULL) {
-		memprintf(err, "out of memory when parsing condition");
+		memprintf(err, "OOM when parsing condition");
 		goto out_return;
 	}
 
@@ -928,7 +928,7 @@ struct acl_cond *parse_acl_cond(const char **args, struct list *known_acl,
 
 			args_new = calloc(1, (arg_end - arg + 1) * sizeof(*args_new));
 			if (!args_new) {
-				memprintf(err, "out of memory when parsing condition");
+				memprintf(err, "OOM when parsing condition");
 				goto out_free_suite;
 			}
 
@@ -962,7 +962,7 @@ struct acl_cond *parse_acl_cond(const char **args, struct list *known_acl,
 
 		cur_term = calloc(1, sizeof(*cur_term));
 		if (cur_term == NULL) {
-			memprintf(err, "out of memory when parsing condition");
+			memprintf(err, "OOM when parsing condition");
 			goto out_free_suite;
 		}
 
@@ -984,7 +984,7 @@ struct acl_cond *parse_acl_cond(const char **args, struct list *known_acl,
 		if (!cur_suite) {
 			cur_suite = calloc(1, sizeof(*cur_suite));
 			if (cur_suite == NULL) {
-				memprintf(err, "out of memory when parsing condition");
+				memprintf(err, "OOM when parsing condition");
 				goto out_free_term;
 			}
 			LIST_INIT(&cur_suite->terms);

--- a/src/arg.c
+++ b/src/arg.c
@@ -445,7 +445,7 @@ int make_arg_list(const char *in, int len, uint64_t mask, struct arg **argp,
 	goto err;
 
 alloc_err:
-	memprintf(err_msg, "out of memory");
+	memprintf(err_msg, "OOM");
 	goto err;
 }
 

--- a/src/cache.c
+++ b/src/cache.c
@@ -1563,20 +1563,20 @@ static int parse_cache_rule(struct proxy *proxy, const char *name, struct act_ru
 	/* Create the filter cache config  */
 	cconf = calloc(1, sizeof(*cconf));
 	if (!cconf) {
-		memprintf(err, "out of memory\n");
+		memprintf(err, "OOM\n");
 		goto err;
 	}
 	cconf->flags = CACHE_FLT_F_IMPLICIT_DECL;
 	cconf->c.name = strdup(name);
 	if (!cconf->c.name) {
-		memprintf(err, "out of memory\n");
+		memprintf(err, "OOM\n");
 		goto err;
 	}
 
 	/* register a filter to fill the cache buffer */
 	fconf = calloc(1, sizeof(*fconf));
 	if (!fconf) {
-		memprintf(err, "out of memory\n");
+		memprintf(err, "OOM\n");
 		goto err;
 	}
 	fconf->id = cache_store_flt_id;
@@ -1883,7 +1883,7 @@ int cfg_parse_cache(const char *file, int linenum, char **args, int kwm)
 
 			tmp_cache_config = calloc(1, sizeof(*tmp_cache_config));
 			if (!tmp_cache_config) {
-				ha_alert("parsing [%s:%d]: out of memory.\n", file, linenum);
+				ha_alert("parsing [%s:%d]: OOM.\n", file, linenum);
 				err_code |= ERR_ALERT | ERR_ABORT;
 				goto out;
 			}
@@ -2498,7 +2498,7 @@ parse_cache_flt(char **args, int *cur_arg, struct proxy *px,
 	}
 	name = strdup(args[pos + 1]);
 	if (!name) {
-		memprintf(err, "%s '%s' : out of memory", args[pos], args[pos + 1]);
+		memprintf(err, "%s '%s' : OOM", args[pos], args[pos + 1]);
 		goto error;
 	}
 	pos += 2;
@@ -2533,7 +2533,7 @@ parse_cache_flt(char **args, int *cur_arg, struct proxy *px,
 	if (!cconf) {
 		cconf = calloc(1, sizeof(*cconf));
 		if (!cconf) {
-			memprintf(err, "%s: out of memory", args[*cur_arg]);
+			memprintf(err, "%s: OOM", args[*cur_arg]);
 			goto error;
 		}
 		cconf->c.name = name;

--- a/src/cfgdiag.c
+++ b/src/cfgdiag.c
@@ -30,7 +30,7 @@ static inline void *diag_alloc(size_t size)
 	void *out = NULL;
 
 	if (!(out = malloc(size))) {
-		fprintf(stderr, "out of memory\n");
+		fprintf(stderr, "OOM\n");
 		exit(1);
 	}
 

--- a/src/cfgparse-listen.c
+++ b/src/cfgparse-listen.c
@@ -3126,7 +3126,7 @@ stats_error_parsing:
 	return err_code;
 
  alloc_error:
-	ha_alert("parsing [%s:%d]: out of memory.\n", file, linenum);
+	ha_alert("parsing [%s:%d]: OOM.\n", file, linenum);
 	err_code |= ERR_ALERT | ERR_ABORT;
 	goto out;
 }

--- a/src/cfgparse-ssl.c
+++ b/src/cfgparse-ssl.c
@@ -317,7 +317,7 @@ static int ssl_parse_global_capture_buffer(char **args, int section_type, struct
 
 	pool_head_ssl_capture = create_pool("ssl-capture", sizeof(struct ssl_capture) + global_ssl.capture_buffer_size, MEM_F_SHARED);
 	if (!pool_head_ssl_capture) {
-		memprintf(err, "Out of memory error.");
+		memprintf(err, "OOM error.");
 		return -1;
 	}
 	return 0;
@@ -347,13 +347,13 @@ static int ssl_parse_global_keylog(char **args, int section_type, struct proxy *
 
 	pool_head_ssl_keylog = create_pool("ssl-keylogfile", sizeof(struct ssl_keylog), MEM_F_SHARED);
 	if (!pool_head_ssl_keylog) {
-		memprintf(err, "Out of memory error.");
+		memprintf(err, "OOM error.");
 		return -1;
 	}
 
 	pool_head_ssl_keylog_str = create_pool("ssl-keylogfile-str", sizeof(char) * SSL_KEYLOG_MAX_SECRET_SIZE, MEM_F_SHARED);
 	if (!pool_head_ssl_keylog_str) {
-		memprintf(err, "Out of memory error.");
+		memprintf(err, "OOM error.");
 		return -1;
 	}
 
@@ -988,7 +988,7 @@ int ssl_sock_parse_alpn(char *arg, char **alpn_str, int *alpn_len, char **err)
 	len  = strlen(arg) + 1;
 	alpn = calloc(1, len+1);
 	if (!alpn) {
-		memprintf(err, "'%s' : out of memory", arg);
+		memprintf(err, "'%s' : OOM", arg);
 		goto error;
 	}
 	memcpy(alpn+1, arg, len);
@@ -1276,7 +1276,7 @@ static int srv_parse_npn(char **args, int *cur_arg, struct proxy *px, struct ser
 	newsrv->ssl_ctx.npn_len = strlen(args[*cur_arg + 1]) + 1;
 	newsrv->ssl_ctx.npn_str = calloc(1, newsrv->ssl_ctx.npn_len + 1);
 	if (!newsrv->ssl_ctx.npn_str) {
-		memprintf(err, "out of memory");
+		memprintf(err, "OOM");
 		return ERR_ALERT | ERR_FATAL;
 	}
 
@@ -1619,7 +1619,7 @@ static int srv_parse_sni(char **args, int *cur_arg, struct proxy *px, struct ser
 	free(newsrv->sni_expr);
 	newsrv->sni_expr = strdup(arg);
 	if (!newsrv->sni_expr) {
-		memprintf(err, "out of memory");
+		memprintf(err, "OOM");
 		return ERR_ALERT | ERR_FATAL;
 	}
 

--- a/src/cfgparse.c
+++ b/src/cfgparse.c
@@ -584,7 +584,7 @@ static int init_peers_frontend(const char *file, int linenum,
 
 	p = calloc(1, sizeof *p);
 	if (!p) {
-		ha_alert("parsing [%s:%d] : out of memory.\n", file, linenum);
+		ha_alert("parsing [%s:%d] : OOM.\n", file, linenum);
 		return -1;
 	}
 
@@ -644,7 +644,7 @@ static struct peer *cfg_peers_add_peer(struct peers *peers,
 
 	p = calloc(1, sizeof *p);
 	if (!p) {
-		ha_alert("parsing [%s:%d] : out of memory.\n", file, linenum);
+		ha_alert("parsing [%s:%d] : OOM.\n", file, linenum);
 		return NULL;
 	}
 
@@ -833,7 +833,7 @@ int cfg_parse_peers(const char *file, int linenum, char **args, int kwm)
 		}
 
 		if ((curpeers = calloc(1, sizeof(*curpeers))) == NULL) {
-			ha_alert("parsing [%s:%d] : out of memory.\n", file, linenum);
+			ha_alert("parsing [%s:%d] : OOM.\n", file, linenum);
 			err_code |= ERR_ALERT | ERR_ABORT;
 			goto out;
 		}
@@ -1081,7 +1081,7 @@ int cfg_parse_mailers(const char *file, int linenum, char **args, int kwm)
 		}
 
 		if ((curmailers = calloc(1, sizeof(*curmailers))) == NULL) {
-			ha_alert("parsing [%s:%d] : out of memory.\n", file, linenum);
+			ha_alert("parsing [%s:%d] : OOM.\n", file, linenum);
 			err_code |= ERR_ALERT | ERR_ABORT;
 			goto out;
 		}
@@ -1116,7 +1116,7 @@ int cfg_parse_mailers(const char *file, int linenum, char **args, int kwm)
 		}
 
 		if ((newmailer = calloc(1, sizeof(*newmailer))) == NULL) {
-			ha_alert("parsing [%s:%d] : out of memory.\n", file, linenum);
+			ha_alert("parsing [%s:%d] : OOM.\n", file, linenum);
 			err_code |= ERR_ALERT | ERR_ABORT;
 			goto out;
 		}
@@ -1294,14 +1294,14 @@ cfg_parse_users(const char *file, int linenum, char **args, int kwm)
 
 		newul = calloc(1, sizeof(*newul));
 		if (!newul) {
-			ha_alert("parsing [%s:%d]: out of memory.\n", file, linenum);
+			ha_alert("parsing [%s:%d]: OOM.\n", file, linenum);
 			err_code |= ERR_ALERT | ERR_ABORT;
 			goto out;
 		}
 
 		newul->name = strdup(args[1]);
 		if (!newul->name) {
-			ha_alert("parsing [%s:%d]: out of memory.\n", file, linenum);
+			ha_alert("parsing [%s:%d]: OOM.\n", file, linenum);
 			err_code |= ERR_ALERT | ERR_ABORT;
 			free(newul);
 			goto out;
@@ -1343,14 +1343,14 @@ cfg_parse_users(const char *file, int linenum, char **args, int kwm)
 
 		ag = calloc(1, sizeof(*ag));
 		if (!ag) {
-			ha_alert("parsing [%s:%d]: out of memory.\n", file, linenum);
+			ha_alert("parsing [%s:%d]: OOM.\n", file, linenum);
 			err_code |= ERR_ALERT | ERR_ABORT;
 			goto out;
 		}
 
 		ag->name = strdup(args[1]);
 		if (!ag->name) {
-			ha_alert("parsing [%s:%d]: out of memory.\n", file, linenum);
+			ha_alert("parsing [%s:%d]: OOM.\n", file, linenum);
 			err_code |= ERR_ALERT | ERR_ABORT;
 			free(ag);
 			goto out;
@@ -1400,7 +1400,7 @@ cfg_parse_users(const char *file, int linenum, char **args, int kwm)
 
 		newuser = calloc(1, sizeof(*newuser));
 		if (!newuser) {
-			ha_alert("parsing [%s:%d]: out of memory.\n", file, linenum);
+			ha_alert("parsing [%s:%d]: OOM.\n", file, linenum);
 			err_code |= ERR_ALERT | ERR_ABORT;
 			goto out;
 		}
@@ -1705,7 +1705,7 @@ int readcfgfile(const char *file)
 	global.cfg_curr_file = file;
 
 	if ((thisline = malloc(sizeof(*thisline) * linesize)) == NULL) {
-		ha_alert("Out of memory trying to allocate a buffer for a configuration line.\n");
+		ha_alert("OOM trying to allocate a buffer for a configuration line.\n");
 		err_code = -1;
 		goto err;
 	}
@@ -3640,7 +3640,7 @@ out_uri_auth_compat:
 				if (!rs) {
 					rs = create_tcpcheck_ruleset("*tcp-check");
 					if (rs == NULL) {
-						ha_alert("config: %s '%s': out of memory.\n",
+						ha_alert("config: %s '%s': OOM.\n",
 							 proxy_type_str(curproxy), curproxy->id);
 						cfgerr++;
 					}
@@ -3848,7 +3848,7 @@ out_uri_auth_compat:
 						cfgerr++;
 				}
 				if (!peers_init_sync(curpeers) || !peers_alloc_dcache(curpeers)) {
-					ha_alert("Peers section '%s': out of memory, giving up on peers.\n",
+					ha_alert("Peers section '%s': OOM, giving up on peers.\n",
 						 curpeers->id);
 					cfgerr++;
 					break;
@@ -4006,7 +4006,7 @@ int cfg_register_section(char *section_name,
 
 	cs = calloc(1, sizeof(*cs));
 	if (!cs) {
-		ha_alert("register section '%s': out of memory.\n", section_name);
+		ha_alert("register section '%s': OOM.\n", section_name);
 		return 0;
 	}
 
@@ -4029,7 +4029,7 @@ int cfg_register_postparser(char *name, int (*func)())
 
 	cp = calloc(1, sizeof(*cp));
 	if (!cp) {
-		ha_alert("register postparser '%s': out of memory.\n", name);
+		ha_alert("register postparser '%s': OOM.\n", name);
 		return 0;
 	}
 	cp->name = name;

--- a/src/check.c
+++ b/src/check.c
@@ -1323,7 +1323,7 @@ const char *init_check(struct check *check, int type)
 
 	check->wait_list.tasklet = tasklet_new();
 	if (!check->wait_list.tasklet)
-		return "out of memory while allocating check tasklet";
+		return "OOM while allocating check tasklet";
 	check->wait_list.events = 0;
 	check->wait_list.tasklet->process = event_srv_chk_io;
 	check->wait_list.tasklet->context = check;
@@ -1395,7 +1395,7 @@ int start_check_task(struct check *check, int mininter,
 
 	/* task for the check */
 	if ((t = task_new(thread_mask)) == NULL) {
-		ha_alert("Starting [%s:%s] check: out of memory.\n",
+		ha_alert("Starting [%s:%s] check: OOM.\n",
 			 check->server->proxy->id, check->server->id);
 		return 0;
 	}
@@ -1483,7 +1483,7 @@ static int start_checks()
 		for (s = px->srv; s; s = s->next) {
 			if (s->slowstart) {
 				if ((t = task_new(MAX_THREADS_MASK)) == NULL) {
-					ha_alert("Starting [%s:%s] check: out of memory.\n", px->id, s->id);
+					ha_alert("Starting [%s:%s] check: OOM.\n", px->id, s->id);
 					return ERR_ALERT | ERR_FATAL;
 				}
 				/* We need a warmup task that will be called when the server
@@ -1526,7 +1526,7 @@ static int start_checks()
 	for (px = proxies_list; px; px = px->next) {
 		if ((px->options2 & PR_O2_CHK_ANY) == PR_O2_EXT_CHK) {
 			if (init_pid_list()) {
-				ha_alert("Starting [%s] check: out of memory.\n", px->id);
+				ha_alert("Starting [%s] check: OOM.\n", px->id);
 				return ERR_ALERT | ERR_FATAL;
 			}
 		}
@@ -1721,7 +1721,7 @@ int init_srv_agent_check(struct server *srv)
 		chk = calloc(1, sizeof(*chk));
 		if (!chk) {
 			ha_alert("%s '%s': unable to add implicit tcp-check connect rule"
-				 " to agent-check for server '%s' (out of memory).\n",
+				 " to agent-check for server '%s' (OOM).\n",
 				 proxy_type_str(srv->proxy), srv->proxy->id, srv->id);
 			ret |= ERR_ALERT | ERR_FATAL;
 			goto out;
@@ -1877,7 +1877,7 @@ static int srv_parse_agent_check(char **args, int *cur_arg, struct proxy *curpx,
 	if (!rules) {
 		rules = calloc(1, sizeof(*rules));
 		if (!rules) {
-			memprintf(errmsg, "out of memory.");
+			memprintf(errmsg, "OOM.");
 			goto error;
 		}
 		LIST_INIT(&rules->preset_vars);
@@ -1892,7 +1892,7 @@ static int srv_parse_agent_check(char **args, int *cur_arg, struct proxy *curpx,
 
 	rs = create_tcpcheck_ruleset("*agent-check");
 	if (rs == NULL) {
-		memprintf(errmsg, "out of memory.");
+		memprintf(errmsg, "OOM.");
 		goto error;
 	}
 
@@ -2060,7 +2060,7 @@ static int srv_parse_agent_send(char **args, int *cur_arg, struct proxy *curpx, 
 	if (!rules) {
 		rules = calloc(1, sizeof(*rules));
 		if (!rules) {
-			memprintf(errmsg, "out of memory.");
+			memprintf(errmsg, "OOM.");
 			goto error;
 		}
 		LIST_INIT(&rules->preset_vars);
@@ -2068,7 +2068,7 @@ static int srv_parse_agent_send(char **args, int *cur_arg, struct proxy *curpx, 
 	}
 
 	if (!set_srv_agent_send(srv, args[*cur_arg+1])) {
-		memprintf(errmsg, "out of memory.");
+		memprintf(errmsg, "OOM.");
 		goto error;
 	}
 

--- a/src/cli.c
+++ b/src/cli.c
@@ -417,14 +417,14 @@ static int cli_parse_global(char **args, int section_type, struct proxy *curpx,
 
 		if (!global.cli_fe) {
 			if ((global.cli_fe = cli_alloc_fe("GLOBAL", file, line)) == NULL) {
-				memprintf(err, "'%s %s' : out of memory trying to allocate a frontend", args[0], args[1]);
+				memprintf(err, "'%s %s' : OOM when trying to allocate a frontend", args[0], args[1]);
 				return -1;
 			}
 		}
 
 		bind_conf = bind_conf_alloc(global.cli_fe, file, line, args[2], xprt_get(XPRT_RAW));
 		if (!bind_conf) {
-			memprintf(err, "'%s %s' : out of memory trying to allocate a bind_conf", args[0], args[1]);
+			memprintf(err, "'%s %s' : OOM when trying to allocate a bind_conf", args[0], args[1]);
 			return -1;
 		}
 		bind_conf->level &= ~ACCESS_LVL_MASK;
@@ -505,7 +505,7 @@ static int cli_parse_global(char **args, int section_type, struct proxy *curpx,
 		}
 		if (!global.cli_fe) {
 			if ((global.cli_fe = cli_alloc_fe("GLOBAL", file, line)) == NULL) {
-				memprintf(err, "'%s %s' : out of memory trying to allocate a frontend", args[0], args[1]);
+				memprintf(err, "'%s %s' : OOM when trying to allocate a frontend", args[0], args[1]);
 				return -1;
 			}
 		}
@@ -521,7 +521,7 @@ static int cli_parse_global(char **args, int section_type, struct proxy *curpx,
 
 		if (!global.cli_fe) {
 			if ((global.cli_fe = cli_alloc_fe("GLOBAL", file, line)) == NULL) {
-				memprintf(err, "'%s %s' : out of memory trying to allocate a frontend", args[0], args[1]);
+				memprintf(err, "'%s %s' : OOM when trying to allocate a frontend", args[0], args[1]);
 				return -1;
 			}
 		}
@@ -533,7 +533,7 @@ static int cli_parse_global(char **args, int section_type, struct proxy *curpx,
 
 		if (!global.cli_fe) {
 			if ((global.cli_fe = cli_alloc_fe("GLOBAL", file, line)) == NULL) {
-				memprintf(err, "'%s %s' : out of memory trying to allocate a frontend", args[0], args[1]);
+				memprintf(err, "'%s %s' : OOM when trying to allocate a frontend", args[0], args[1]);
 				return -1;
 			}
 		}
@@ -985,7 +985,7 @@ static void cli_io_handler(struct appctx *appctx)
 					msg = appctx->ctx.cli.err;
 					if (!msg) {
 						sev = LOG_ERR;
-						msg = "Out of memory.\n";
+						msg = "OOM.\n";
 					}
 				}
 				else {
@@ -2877,7 +2877,7 @@ int mworker_cli_sockpair_new(struct mworker_proc *mworker_proc, int proc)
 	/* XXX: we might want to use a separate frontend at some point */
 	if (!global.cli_fe) {
 		if ((global.cli_fe = cli_alloc_fe("GLOBAL", "master-socket", 0)) == NULL) {
-			ha_alert("out of memory trying to allocate the stats frontend");
+			ha_alert("OOM when trying to allocate the stats frontend");
 			goto error;
 		}
 	}

--- a/src/dns.c
+++ b/src/dns.c
@@ -881,7 +881,7 @@ static struct appctx *dns_session_create(struct dns_session *ds)
 
 	sess = session_new(ds->dss->srv->proxy, NULL, &appctx->obj_type);
 	if (!sess) {
-		ha_alert("out of memory in peer_session_create().\n");
+		ha_alert("OOM in peer_session_create().\n");
 		goto out_free_appctx;
 	}
 

--- a/src/extcheck.c
+++ b/src/extcheck.c
@@ -282,7 +282,7 @@ int prepare_external_check(struct check *check)
 
 	check->argv = calloc(6, sizeof(*check->argv));
 	if (!check->argv) {
-		ha_alert("Starting [%s:%s] check: out of memory.\n", px->id, s->id);
+		ha_alert("Starting [%s:%s] check: OOM.\n", px->id, s->id);
 		goto err;
 	}
 
@@ -312,14 +312,14 @@ int prepare_external_check(struct check *check)
 	}
 
 	if (!check->argv[1] || !check->argv[2]) {
-		ha_alert("Starting [%s:%s] check: out of memory.\n", px->id, s->id);
+		ha_alert("Starting [%s:%s] check: OOM.\n", px->id, s->id);
 		goto err;
 	}
 
 	check->argv[3] = calloc(EXTCHK_SIZE_ADDR, sizeof(*check->argv[3]));
 	check->argv[4] = calloc(EXTCHK_SIZE_UINT, sizeof(*check->argv[4]));
 	if (!check->argv[3] || !check->argv[4]) {
-		ha_alert("Starting [%s:%s] check: out of memory.\n", px->id, s->id);
+		ha_alert("Starting [%s:%s] check: OOM.\n", px->id, s->id);
 		goto err;
 	}
 
@@ -329,7 +329,7 @@ int prepare_external_check(struct check *check)
 
 	for (i = 0; i < 5; i++) {
 		if (!check->argv[i]) {
-			ha_alert("Starting [%s:%s] check: out of memory.\n", px->id, s->id);
+			ha_alert("Starting [%s:%s] check: OOM.\n", px->id, s->id);
 			goto err;
 		}
 	}

--- a/src/fcgi-app.c
+++ b/src/fcgi-app.c
@@ -253,7 +253,7 @@ static int fcgi_flt_check(struct proxy *px, struct flt_conf *fconf)
 	list_for_each_entry_safe(crule, back, &fcgi_conf->app->conf.rules, list) {
 		rule = calloc(1, sizeof(*rule));
 		if (!rule) {
-			ha_alert("proxy '%s' : out of memory.\n", px->id);
+			ha_alert("proxy '%s' : OOM.\n", px->id);
 			goto err;
 		}
 		rule->type = crule->type;
@@ -533,7 +533,7 @@ parse_fcgi_flt(char **args, int *cur_arg, struct proxy *px,
 	}
 	name = strdup(args[pos + 1]);
 	if (!name) {
-		memprintf(err, "%s '%s' : out of memory", args[pos], args[pos + 1]);
+		memprintf(err, "%s '%s' : OOM", args[pos], args[pos + 1]);
 		goto err;
 	}
 	pos += 2;
@@ -559,7 +559,7 @@ parse_fcgi_flt(char **args, int *cur_arg, struct proxy *px,
 	if (!fcgi_conf) {
 		fcgi_conf = calloc(1, sizeof(*fcgi_conf));
 		if (!fcgi_conf) {
-			memprintf(err, "%s: out of memory", args[*cur_arg]);
+			memprintf(err, "%s: OOM", args[*cur_arg]);
 			goto err;
 		}
 		fcgi_conf->name = name;
@@ -636,7 +636,7 @@ static int proxy_parse_use_fcgi_app(char **args, int section, struct proxy *curp
 		free(fcgi_conf->name);
 		free(fcgi_conf);
 	}
-	memprintf(err, "out of memory");
+	memprintf(err, "OOM");
 	retval = -1;
 	goto end;
 }
@@ -756,7 +756,7 @@ static int fcgi_app_add_rule(struct fcgi_app *curapp, enum fcgi_rule_type type, 
 		prune_acl_cond(cond);
 		free(cond);
 	}
-	memprintf(err, "out of memory");
+	memprintf(err, "OOM");
 	return 0;
 }
 
@@ -799,7 +799,7 @@ static int cfg_parse_fcgi_app(const char *file, int linenum, char **args, int kw
 
 		curapp = calloc(1, sizeof(*curapp));
 		if (!curapp) {
-			ha_alert("parsing [%s:%d] : out of memory.\n", file, linenum);
+			ha_alert("parsing [%s:%d] : OOM.\n", file, linenum);
 			err_code |= ERR_ALERT | ERR_ABORT;
 			goto out;
 		}
@@ -855,7 +855,7 @@ static int cfg_parse_fcgi_app(const char *file, int linenum, char **args, int kw
 		istfree(&curapp->docroot);
 		curapp->docroot = ist(strdup(args[1]));
 		if (!isttest(curapp->docroot)) {
-			ha_alert("parsing [%s:%d] : out of memory.\n", file, linenum);
+			ha_alert("parsing [%s:%d] : OOM.\n", file, linenum);
 			err_code |= ERR_ALERT | ERR_ABORT;
 		}
 	}
@@ -888,7 +888,7 @@ static int cfg_parse_fcgi_app(const char *file, int linenum, char **args, int kw
 		istfree(&curapp->index);
 		curapp->index = ist(strdup(args[1]));
 		if (!isttest(curapp->index)) {
-			ha_alert("parsing [%s:%d] : out of memory.\n", file, linenum);
+			ha_alert("parsing [%s:%d] : OOM.\n", file, linenum);
 			err_code |= ERR_ALERT | ERR_ABORT;
 		}
 	}

--- a/src/filters.c
+++ b/src/filters.c
@@ -197,7 +197,7 @@ parse_filter(char **args, int section_type, struct proxy *curpx,
 		}
 		fconf = calloc(1, sizeof(*fconf));
 		if (!fconf) {
-			memprintf(err, "'%s' : out of memory", args[0]);
+			memprintf(err, "'%s' : OOM", args[0]);
 			goto error;
 		}
 

--- a/src/flt_http_comp.c
+++ b/src/flt_http_comp.c
@@ -655,7 +655,7 @@ parse_compression_options(char **args, int section, struct proxy *proxy,
 					memprintf(err, "'%s' : '%s' is not a supported algorithm.\n",
 						  args[0], args[cur_arg]);
 				else
-					memprintf(err, "'%s' : out of memory while parsing algo '%s'.\n",
+					memprintf(err, "'%s' : OOM while parsing algo '%s'.\n",
 						  args[0], args[cur_arg]);
 				return -1;
 			}
@@ -682,7 +682,7 @@ parse_compression_options(char **args, int section, struct proxy *proxy,
 		}
 		while (*(args[cur_arg])) {
 			if (comp_append_type(comp, args[cur_arg])) {
-				memprintf(err, "'%s': out of memory.", args[0]);
+				memprintf(err, "'%s': OOM.", args[0]);
 				return -1;
 			}
 			cur_arg++;
@@ -762,7 +762,7 @@ check_implicit_http_comp_flt(struct proxy *proxy)
 	 * one */
 	fconf = calloc(1, sizeof(*fconf));
 	if (!fconf) {
-		ha_alert("config: %s '%s': out of memory\n",
+		ha_alert("config: %s '%s': OOM\n",
 			 proxy_type_str(proxy), proxy->id);
 		err++;
 		goto end;

--- a/src/flt_spoe.c
+++ b/src/flt_spoe.c
@@ -3099,7 +3099,7 @@ spoe_check(struct proxy *px, struct flt_conf *fconf)
 	}
 
 	if ((conf->agent->rt = calloc(global.nbthread, sizeof(*conf->agent->rt))) == NULL) {
-		ha_alert("Proxy %s : out of memory initializing SPOE agent '%s' declared at %s:%d.\n",
+		ha_alert("Proxy %s : OOM initializing SPOE agent '%s' declared at %s:%d.\n",
 			 px->id, conf->agent->id, conf->agent->conf.file, conf->agent->conf.line);
 		return 1;
 	}
@@ -3397,7 +3397,7 @@ cfg_parse_spoe_agent(const char *file, int linenum, char **args, int kwm)
 			goto out;
 		}
 		if ((curagent = calloc(1, sizeof(*curagent))) == NULL) {
-			ha_alert("parsing [%s:%d] : out of memory.\n", file, linenum);
+			ha_alert("parsing [%s:%d] : OOM.\n", file, linenum);
 			err_code |= ERR_ALERT | ERR_ABORT;
 			goto out;
 		}
@@ -3453,7 +3453,7 @@ cfg_parse_spoe_agent(const char *file, int linenum, char **args, int kwm)
 			}
 
 			if ((ph = calloc(1, sizeof(*ph))) == NULL) {
-				ha_alert("parsing [%s:%d] : out of memory.\n", file, linenum);
+				ha_alert("parsing [%s:%d] : OOM.\n", file, linenum);
 				err_code |= ERR_ALERT | ERR_ABORT;
 				goto out;
 			}
@@ -3477,7 +3477,7 @@ cfg_parse_spoe_agent(const char *file, int linenum, char **args, int kwm)
 			}
 
 			if ((ph = calloc(1, sizeof(*ph))) == NULL) {
-				ha_alert("parsing [%s:%d] : out of memory.\n", file, linenum);
+				ha_alert("parsing [%s:%d] : OOM.\n", file, linenum);
 				err_code |= ERR_ALERT | ERR_ABORT;
 				goto out;
 			}
@@ -3775,13 +3775,13 @@ cfg_parse_spoe_agent(const char *file, int linenum, char **args, int kwm)
 			struct spoe_var_placeholder *vph;
 
 			if ((vph = calloc(1, sizeof(*vph))) == NULL) {
-				ha_alert("parsing [%s:%d] : out of memory.\n", file, linenum);
+				ha_alert("parsing [%s:%d] : OOM.\n", file, linenum);
 				err_code |= ERR_ALERT | ERR_ABORT;
 				goto out;
 			}
 			if ((vph->name  = strdup(args[cur_arg])) == NULL) {
 				free(vph);
-				ha_alert("parsing [%s:%d] : out of memory.\n", file, linenum);
+				ha_alert("parsing [%s:%d] : OOM.\n", file, linenum);
 				err_code |= ERR_ALERT | ERR_ABORT;
 				goto out;
 			}
@@ -3850,7 +3850,7 @@ cfg_parse_spoe_group(const char *file, int linenum, char **args, int kwm)
 		}
 
 		if ((curgrp = calloc(1, sizeof(*curgrp))) == NULL) {
-			ha_alert("parsing [%s:%d] : out of memory.\n", file, linenum);
+			ha_alert("parsing [%s:%d] : OOM.\n", file, linenum);
 			err_code |= ERR_ALERT | ERR_ABORT;
 			goto out;
 		}
@@ -3877,7 +3877,7 @@ cfg_parse_spoe_group(const char *file, int linenum, char **args, int kwm)
 			}
 
 			if ((ph = calloc(1, sizeof(*ph))) == NULL) {
-				ha_alert("parsing [%s:%d] : out of memory.\n", file, linenum);
+				ha_alert("parsing [%s:%d] : OOM.\n", file, linenum);
 				err_code |= ERR_ALERT | ERR_ABORT;
 				goto out;
 			}
@@ -3941,7 +3941,7 @@ cfg_parse_spoe_message(const char *file, int linenum, char **args, int kwm)
 		}
 
 		if ((curmsg = calloc(1, sizeof(*curmsg))) == NULL) {
-			ha_alert("parsing [%s:%d] : out of memory.\n", file, linenum);
+			ha_alert("parsing [%s:%d] : OOM.\n", file, linenum);
 			err_code |= ERR_ALERT | ERR_ABORT;
 			goto out;
 		}
@@ -3969,7 +3969,7 @@ cfg_parse_spoe_message(const char *file, int linenum, char **args, int kwm)
 			int   idx = 0;
 
 			if ((arg = calloc(1, sizeof(*arg))) == NULL) {
-				ha_alert("parsing [%s:%d] : out of memory.\n", file, linenum);
+				ha_alert("parsing [%s:%d] : OOM.\n", file, linenum);
 				err_code |= ERR_ALERT | ERR_ABORT;
 				goto out;
 			}
@@ -4117,7 +4117,7 @@ parse_spoe_flt(char **args, int *cur_arg, struct proxy *px,
 
 	conf = calloc(1, sizeof(*conf));
 	if (conf == NULL) {
-		memprintf(err, "%s: out of memory", args[*cur_arg]);
+		memprintf(err, "%s: OOM", args[*cur_arg]);
 		goto error;
 	}
 	conf->proxy = px;

--- a/src/flt_trace.c
+++ b/src/flt_trace.c
@@ -617,7 +617,7 @@ parse_trace_flt(char **args, int *cur_arg, struct proxy *px,
 
 	conf = calloc(1, sizeof(*conf));
 	if (!conf) {
-		memprintf(err, "%s: out of memory", args[*cur_arg]);
+		memprintf(err, "%s: OOM", args[*cur_arg]);
 		return -1;
 	}
 	conf->proxy = px;
@@ -634,7 +634,7 @@ parse_trace_flt(char **args, int *cur_arg, struct proxy *px,
 				}
 				conf->name = strdup(args[pos + 1]);
 				if (!conf->name) {
-					memprintf(err, "%s: out of memory", args[*cur_arg]);
+					memprintf(err, "%s: OOM", args[*cur_arg]);
 					goto error;
 				}
 				pos++;

--- a/src/haproxy.c
+++ b/src/haproxy.c
@@ -306,7 +306,7 @@ void hap_register_build_opts(const char *str, int must_free)
 
 	b = calloc(1, sizeof(*b));
 	if (!b) {
-		fprintf(stderr, "out of memory\n");
+		fprintf(stderr, "OOM\n");
 		exit(1);
 	}
 	b->str = str;
@@ -1030,7 +1030,7 @@ static void cfgfiles_expand_directories(void)
 				goto next_dir_entry;
 
 			if (!memprintf(&filename, "%s/%s", wl->s, dir_entry->d_name)) {
-				ha_alert("Cannot load configuration files %s : out of memory.\n",
+				ha_alert("Cannot load configuration files %s : OOM.\n",
 					 filename);
 				exit(1);
 			}
@@ -1691,7 +1691,7 @@ static void init(int argc, char **argv)
 					char * endptr = NULL;
 					oldpids = realloc(oldpids, (nb_oldpids + 1) * sizeof(int));
 					if (!oldpids) {
-						ha_alert("Cannot allocate old pid : out of memory.\n");
+						ha_alert("Cannot allocate old pid : OOM.\n");
 						exit(1);
 					}
 					argc--; argv++;

--- a/src/hlua.c
+++ b/src/hlua.c
@@ -1160,7 +1160,7 @@ __LJMP void hlua_yieldk(lua_State *L, int nresults, int ctx,
  * an LUA coroutine. It can not be use to crete the main LUA context.
  *
  * This function is particular. it initialises a new Lua thread. If the
- * initialisation fails (example: out of memory error), the lua function
+ * initialisation fails (example: OOM error), the lua function
  * throws an error (longjmp).
  *
  * In some case (at least one), this function can be called from safe
@@ -2204,7 +2204,7 @@ connection_empty:
 
 	if (!notification_new(&hlua->com, &appctx->ctx.hlua_cosocket.wake_on_read, hlua->task)) {
 		xref_unlock(&socket->xref, peer);
-		WILL_LJMP(luaL_error(L, "out of memory"));
+		WILL_LJMP(luaL_error(L, "OOM"));
 	}
 	xref_unlock(&socket->xref, peer);
 	MAY_LJMP(hlua_yieldk(L, 0, 0, hlua_socket_receive_yield, TICK_ETERNITY, 0));
@@ -2411,7 +2411,7 @@ static int hlua_socket_write_yield(struct lua_State *L,int status, lua_KContext 
 hlua_socket_write_yield_return:
 	if (!notification_new(&hlua->com, &appctx->ctx.hlua_cosocket.wake_on_write, hlua->task)) {
 		xref_unlock(&socket->xref, peer);
-		WILL_LJMP(luaL_error(L, "out of memory"));
+		WILL_LJMP(luaL_error(L, "OOM"));
 	}
 	xref_unlock(&socket->xref, peer);
 	MAY_LJMP(hlua_yieldk(L, 0, 0, hlua_socket_write_yield, TICK_ETERNITY, 0));
@@ -2693,7 +2693,7 @@ __LJMP static int hlua_socket_connect_yield(struct lua_State *L, int status, lua
 
 	if (!notification_new(&hlua->com, &appctx->ctx.hlua_cosocket.wake_on_write, hlua->task)) {
 		xref_unlock(&socket->xref, peer);
-		WILL_LJMP(luaL_error(L, "out of memory error"));
+		WILL_LJMP(luaL_error(L, "OOM error"));
 	}
 	xref_unlock(&socket->xref, peer);
 	MAY_LJMP(hlua_yieldk(L, 0, 0, hlua_socket_connect_yield, TICK_ETERNITY, 0));
@@ -2800,7 +2800,7 @@ __LJMP static int hlua_socket_connect(struct lua_State *L)
 
 	if (!notification_new(&hlua->com, &appctx->ctx.hlua_cosocket.wake_on_write, hlua->task)) {
 		xref_unlock(&socket->xref, peer);
-		WILL_LJMP(luaL_error(L, "out of memory"));
+		WILL_LJMP(luaL_error(L, "OOM"));
 	}
 	xref_unlock(&socket->xref, peer);
 
@@ -2942,7 +2942,7 @@ __LJMP static int hlua_socket_new(lua_State *L)
 	/* Create the applet context */
 	appctx = appctx_new(&update_applet);
 	if (!appctx) {
-		hlua_pusherror(L, "socket: out of memory");
+		hlua_pusherror(L, "socket: OOM");
 		goto out_fail_conf;
 	}
 
@@ -2954,13 +2954,13 @@ __LJMP static int hlua_socket_new(lua_State *L)
 	/* Now create a session, task and stream for this applet */
 	sess = session_new(socket_proxy, NULL, &appctx->obj_type);
 	if (!sess) {
-		hlua_pusherror(L, "socket: out of memory");
+		hlua_pusherror(L, "socket: OOM");
 		goto out_fail_sess;
 	}
 
 	strm = stream_new(sess, &appctx->obj_type, &BUF_NULL);
 	if (!strm) {
-		hlua_pusherror(L, "socket: out of memory");
+		hlua_pusherror(L, "socket: OOM");
 		goto out_fail_stream;
 	}
 
@@ -7973,7 +7973,7 @@ __LJMP static int hlua_register_init(lua_State *L)
 
 	init = calloc(1, sizeof(*init));
 	if (!init)
-		WILL_LJMP(luaL_error(L, "Lua out of memory error."));
+		WILL_LJMP(luaL_error(L, "Lua OOM error."));
 
 	init->function_ref = ref;
 	LIST_APPEND(&hlua_init_functions[hlua_state_id], &init->l);
@@ -8044,7 +8044,7 @@ static int hlua_register_task(lua_State *L)
   alloc_error:
 	task_destroy(task);
 	hlua_ctx_destroy(hlua);
-	WILL_LJMP(luaL_error(L, "Lua out of memory error."));
+	WILL_LJMP(luaL_error(L, "Lua OOM error."));
 	return 0; /* Never reached */
 }
 
@@ -8165,7 +8165,7 @@ static int hlua_sample_conv_wrapper(const struct arg *arg_p, struct sample *smp,
 		return 0;
 
 	case HLUA_E_NOMEM:
-		SEND_ERR(stream->be, "Lua converter '%s': out of memory error.\n", fcn->name);
+		SEND_ERR(stream->be, "Lua converter '%s': OOM error.\n", fcn->name);
 		return 0;
 
 	case HLUA_E_YIELD:
@@ -8303,7 +8303,7 @@ static int hlua_sample_fetch_wrapper(const struct arg *arg_p, struct sample *smp
 		return 0;
 
 	case HLUA_E_NOMEM:
-		SEND_ERR(smp->px, "Lua sample-fetch '%s': out of memory error.\n", fcn->name);
+		SEND_ERR(smp->px, "Lua sample-fetch '%s': OOM error.\n", fcn->name);
 		return 0;
 
 	case HLUA_E_YIELD:
@@ -8395,7 +8395,7 @@ __LJMP static int hlua_register_converters(lua_State *L)
   alloc_error:
 	release_hlua_function(fcn);
 	ha_free(&sck);
-	WILL_LJMP(luaL_error(L, "Lua out of memory error."));
+	WILL_LJMP(luaL_error(L, "Lua OOM error."));
 	return 0; /* Never reached */
 }
 
@@ -8475,7 +8475,7 @@ __LJMP static int hlua_register_fetches(lua_State *L)
   alloc_error:
 	release_hlua_function(fcn);
 	ha_free(&sfk);
-	WILL_LJMP(luaL_error(L, "Lua out of memory error."));
+	WILL_LJMP(luaL_error(L, "Lua OOM error."));
 	return 0; /* Never reached */
 }
 
@@ -8657,7 +8657,7 @@ static enum act_return hlua_action(struct act_rule *rule, struct proxy *px,
 		goto end;
 
 	case HLUA_E_NOMEM:
-		SEND_ERR(px, "Lua function '%s': out of memory error.\n", rule->arg.hlua_rule->fcn->name);
+		SEND_ERR(px, "Lua function '%s': OOM error.\n", rule->arg.hlua_rule->fcn->name);
 		goto end;
 
 	case HLUA_E_YIELD:
@@ -8701,7 +8701,7 @@ static int hlua_applet_tcp_init(struct appctx *ctx, struct proxy *px, struct str
 
 	hlua = pool_alloc(pool_head_hlua);
 	if (!hlua) {
-		SEND_ERR(px, "Lua applet tcp '%s': out of memory.\n",
+		SEND_ERR(px, "Lua applet tcp '%s': OOM.\n",
 		         ctx->rule->arg.hlua_rule->fcn->name);
 		return 0;
 	}
@@ -8712,7 +8712,7 @@ static int hlua_applet_tcp_init(struct appctx *ctx, struct proxy *px, struct str
 	/* Create task used by signal to wakeup applets. */
 	task = task_new(tid_bit);
 	if (!task) {
-		SEND_ERR(px, "Lua applet tcp '%s': out of memory.\n",
+		SEND_ERR(px, "Lua applet tcp '%s': OOM.\n",
 		         ctx->rule->arg.hlua_rule->fcn->name);
 		return 0;
 	}
@@ -8839,7 +8839,7 @@ void hlua_applet_tcp_fct(struct appctx *ctx)
 		goto error;
 
 	case HLUA_E_NOMEM:
-		SEND_ERR(px, "Lua applet tcp '%s': out of memory error.\n",
+		SEND_ERR(px, "Lua applet tcp '%s': OOM error.\n",
 		         rule->arg.hlua_rule->fcn->name);
 		goto error;
 
@@ -8890,7 +8890,7 @@ static int hlua_applet_http_init(struct appctx *ctx, struct proxy *px, struct st
 	txn = strm->txn;
 	hlua = pool_alloc(pool_head_hlua);
 	if (!hlua) {
-		SEND_ERR(px, "Lua applet http '%s': out of memory.\n",
+		SEND_ERR(px, "Lua applet http '%s': OOM.\n",
 		         ctx->rule->arg.hlua_rule->fcn->name);
 		return 0;
 	}
@@ -8905,7 +8905,7 @@ static int hlua_applet_http_init(struct appctx *ctx, struct proxy *px, struct st
 	/* Create task used by signal to wakeup applets. */
 	task = task_new(tid_bit);
 	if (!task) {
-		SEND_ERR(px, "Lua applet http '%s': out of memory.\n",
+		SEND_ERR(px, "Lua applet http '%s': OOM.\n",
 		         ctx->rule->arg.hlua_rule->fcn->name);
 		return 0;
 	}
@@ -9044,7 +9044,7 @@ void hlua_applet_http_fct(struct appctx *ctx)
 			goto error;
 
 		case HLUA_E_NOMEM:
-			SEND_ERR(px, "Lua applet http '%s': out of memory error.\n",
+			SEND_ERR(px, "Lua applet http '%s': OOM error.\n",
 			         rule->arg.hlua_rule->fcn->name);
 			goto error;
 
@@ -9142,7 +9142,7 @@ static enum act_parse_ret action_register_lua(const char **args, int *cur_arg, s
 	/* Memory for the rule. */
 	rule->arg.hlua_rule = calloc(1, sizeof(*rule->arg.hlua_rule));
 	if (!rule->arg.hlua_rule) {
-		memprintf(err, "out of memory error");
+		memprintf(err, "OOM error");
 		goto error;
 	}
 
@@ -9150,7 +9150,7 @@ static enum act_parse_ret action_register_lua(const char **args, int *cur_arg, s
 	rule->arg.hlua_rule->args = calloc(fcn->nargs + 1,
 					   sizeof(*rule->arg.hlua_rule->args));
 	if (!rule->arg.hlua_rule->args) {
-		memprintf(err, "out of memory error");
+		memprintf(err, "OOM error");
 		goto error;
 	}
 
@@ -9165,7 +9165,7 @@ static enum act_parse_ret action_register_lua(const char **args, int *cur_arg, s
 		}
 		rule->arg.hlua_rule->args[i] = strdup(args[*cur_arg]);
 		if (!rule->arg.hlua_rule->args[i]) {
-			memprintf(err, "out of memory error");
+			memprintf(err, "OOM error");
 			goto error;
 		}
 		(*cur_arg)++;
@@ -9207,7 +9207,7 @@ static enum act_parse_ret action_register_service_http(const char **args, int *c
 	/* Memory for the rule. */
 	rule->arg.hlua_rule = calloc(1, sizeof(*rule->arg.hlua_rule));
 	if (!rule->arg.hlua_rule) {
-		memprintf(err, "out of memory error");
+		memprintf(err, "OOM error");
 		return ACT_RET_PRS_ERR;
 	}
 
@@ -9360,7 +9360,7 @@ __LJMP static int hlua_register_action(lua_State *L)
   alloc_error:
 	release_hlua_function(fcn);
 	ha_free(&akl);
-	WILL_LJMP(luaL_error(L, "Lua out of memory error."));
+	WILL_LJMP(luaL_error(L, "Lua OOM error."));
 	return 0; /* Never reached */
 }
 
@@ -9377,7 +9377,7 @@ static enum act_parse_ret action_register_service_tcp(const char **args, int *cu
 	/* Memory for the rule. */
 	rule->arg.hlua_rule = calloc(1, sizeof(*rule->arg.hlua_rule));
 	if (!rule->arg.hlua_rule) {
-		memprintf(err, "out of memory error");
+		memprintf(err, "OOM error");
 		return ACT_RET_PRS_ERR;
 	}
 
@@ -9493,7 +9493,7 @@ __LJMP static int hlua_register_service(lua_State *L)
   alloc_error:
 	release_hlua_function(fcn);
 	ha_free(&akl);
-	WILL_LJMP(luaL_error(L, "Lua out of memory error."));
+	WILL_LJMP(luaL_error(L, "Lua OOM error."));
 	return 0; /* Never reached */
 }
 
@@ -9512,7 +9512,7 @@ static int hlua_cli_parse_fct(char **args, char *payload, struct appctx *appctx,
 
 	hlua = pool_alloc(pool_head_hlua);
 	if (!hlua) {
-		SEND_ERR(NULL, "Lua cli '%s': out of memory.\n", fcn->name);
+		SEND_ERR(NULL, "Lua cli '%s': OOM.\n", fcn->name);
 		return 1;
 	}
 	HLUA_INIT(hlua);
@@ -9524,7 +9524,7 @@ static int hlua_cli_parse_fct(char **args, char *payload, struct appctx *appctx,
 	 */
 	appctx->ctx.hlua_cli.task = task_new(tid_bit);
 	if (!appctx->ctx.hlua_cli.task) {
-		SEND_ERR(NULL, "Lua cli '%s': out of memory.\n", fcn->name);
+		SEND_ERR(NULL, "Lua cli '%s': OOM.\n", fcn->name);
 		goto error;
 	}
 	appctx->ctx.hlua_cli.task->nice = 0;
@@ -9638,7 +9638,7 @@ static int hlua_cli_io_handler_fct(struct appctx *appctx)
 		return 1;
 
 	case HLUA_E_NOMEM:
-		SEND_ERR(NULL, "Lua converter '%s': out of memory error.\n",
+		SEND_ERR(NULL, "Lua converter '%s': OOM error.\n",
 		         fcn->name);
 		return 1;
 
@@ -9730,12 +9730,12 @@ __LJMP static int hlua_register_cli(lua_State *L)
 	/* Allocate and fill the sample fetch keyword struct. */
 	cli_kws = calloc(1, sizeof(*cli_kws) + sizeof(struct cli_kw) * 2);
 	if (!cli_kws) {
-		errmsg = "Lua out of memory error.";
+		errmsg = "Lua OOM error.";
 		goto error;
 	}
 	fcn = new_hlua_function();
 	if (!fcn) {
-		errmsg = "Lua out of memory error.";
+		errmsg = "Lua OOM error.";
 		goto error;
 	}
 
@@ -9753,7 +9753,7 @@ __LJMP static int hlua_register_cli(lua_State *L)
 		}
 		cli_kws->kw[0].str_kw[index] = strdup(lua_tostring(L, -1));
 		if (!cli_kws->kw[0].str_kw[index]) {
-			errmsg = "Lua out of memory error.";
+			errmsg = "Lua OOM error.";
 			goto error;
 		}
 		index++;
@@ -9763,7 +9763,7 @@ __LJMP static int hlua_register_cli(lua_State *L)
 	/* Copy help message. */
 	cli_kws->kw[0].usage = strdup(message);
 	if (!cli_kws->kw[0].usage) {
-		errmsg = "Lua out of memory error.";
+		errmsg = "Lua OOM error.";
 		goto error;
 	}
 
@@ -9773,7 +9773,7 @@ __LJMP static int hlua_register_cli(lua_State *L)
 		len += strlen(cli_kws->kw[0].str_kw[i]) + 1;
 	fcn->name = calloc(1, len);
 	if (!fcn->name) {
-		errmsg = "Lua out of memory error.";
+		errmsg = "Lua OOM error.";
 		goto error;
 	}
 	strncat((char *)fcn->name, "<lua.cli", len);
@@ -9862,7 +9862,7 @@ static int hlua_filter_init_per_thread(struct proxy *px, struct flt_conf *fconf)
 		ha_alert("Lua filter '%s' : runtime error : %s", conf->reg->name, lua_tostring(L, -1));
 		goto error;
 	case LUA_ERRMEM:
-		ha_alert("Lua filter '%s' : out of memory error", conf->reg->name);
+		ha_alert("Lua filter '%s' : OOM error", conf->reg->name);
 		goto error;
 	case LUA_ERRERR:
 		ha_alert("Lua filter '%s' : message handler error : %s", conf->reg->name, lua_tostring(L, -1));
@@ -10056,7 +10056,7 @@ static int hlua_filter_new(struct stream *s, struct filter *filter)
 		ret = 0;
 		goto end;
 	case HLUA_E_NOMEM:
-		SEND_ERR(s->be, "Lua filter '%s' : out of memory error.\n", conf->reg->name);
+		SEND_ERR(s->be, "Lua filter '%s' : OOM error.\n", conf->reg->name);
 		ret = 0;
 		goto end;
 	case HLUA_E_AGAIN:
@@ -10241,7 +10241,7 @@ static int hlua_filter_callback(struct stream *s, struct filter *filter, const c
 		SEND_ERR(s->be, "Lua filter '%s' : '%s' callback execution timeout.\n", conf->reg->name, fun);
 		goto end;
 	case HLUA_E_NOMEM:
-		SEND_ERR(s->be, "Lua filter '%s' : out of memory error.\n", conf->reg->name);
+		SEND_ERR(s->be, "Lua filter '%s' : OOM error.\n", conf->reg->name);
 		goto end;
 	case HLUA_E_YIELD:
 		SEND_ERR(s->be, "Lua filter '%s': yield functions like core.tcp() or core.sleep()"
@@ -10440,7 +10440,7 @@ static int hlua_filter_parse_fct(char **args, int *cur_arg, struct proxy *px,
 	return 0;
 
   error:
-	memprintf(err, "Lua filter '%s' : Lua out of memory error", reg_flt->name);
+	memprintf(err, "Lua filter '%s' : Lua OOM error", reg_flt->name);
 	free(hlua_flt_ops);
 	if (conf && conf->args) {
 		for (pos = 0; conf->args[pos]; pos++)
@@ -10560,7 +10560,7 @@ __LJMP static int hlua_register_filter(lua_State *L)
   alloc_error:
 	release_hlua_reg_filter(reg_flt);
 	ha_free(&fkl);
-	WILL_LJMP(luaL_error(L, "Lua out of memory error."));
+	WILL_LJMP(luaL_error(L, "Lua OOM error."));
 	return 0; /* Never reached */
 }
 
@@ -10681,7 +10681,7 @@ static int hlua_load_state(char *filename, lua_State *L, char **err)
 		lua_pop(L, 1);
 		return -1;
 	case LUA_ERRMEM:
-		memprintf(err, "Lua out of memory error\n");
+		memprintf(err, "Lua OOM error\n");
 		return -1;
 	case LUA_ERRERR:
 		memprintf(err, "Lua message handler error: %s\n", lua_tostring(L, -1));
@@ -10732,7 +10732,7 @@ static int hlua_load_per_thread(char **args, int section_type, struct proxy *cur
 		/* allocate the first entry large enough to store the final NULL */
 		per_thread_load = calloc(1, sizeof(*per_thread_load));
 		if (per_thread_load == NULL) {
-			memprintf(err, "out of memory error");
+			memprintf(err, "OOM error");
 			return -1;
 		}
 	}
@@ -10743,7 +10743,7 @@ static int hlua_load_per_thread(char **args, int section_type, struct proxy *cur
 
 	per_thread_load = realloc(per_thread_load, (len + 2) * sizeof(*per_thread_load));
 	if (per_thread_load == NULL) {
-		memprintf(err, "out of memory error");
+		memprintf(err, "OOM error");
 		return -1;
 	}
 
@@ -10751,7 +10751,7 @@ static int hlua_load_per_thread(char **args, int section_type, struct proxy *cur
 	per_thread_load[len + 1] = NULL;
 
 	if (per_thread_load[len] == NULL) {
-		memprintf(err, "out of memory error");
+		memprintf(err, "OOM error");
 		return -1;
 	}
 
@@ -10927,7 +10927,7 @@ int hlua_post_init_state(lua_State *L)
 			/* Fall through */
 		case LUA_ERRMEM:
 			if (!kind)
-				kind = "out of memory error";
+				kind = "OOM error";
 			lua_settop(L, 0);
 			lua_pop(L, 1);
 			trace = hlua_traceback(L, ", ");

--- a/src/http_act.c
+++ b/src/http_act.c
@@ -944,7 +944,7 @@ static enum act_parse_ret parse_http_req_capture(const char **args, int *orig_ar
 
 		hdr = calloc(1, sizeof(*hdr));
 		if (!hdr) {
-			memprintf(err, "out of memory");
+			memprintf(err, "OOM");
 			release_sample_expr(expr);
 			return ACT_RET_PRS_ERR;
 		}

--- a/src/http_ana.c
+++ b/src/http_ana.c
@@ -260,7 +260,7 @@ int http_wait_for_request(struct stream *s, struct channel *req, int an_bit)
 			if (!(s->logs.logwait &= ~(LW_REQ|LW_INIT)))
 				s->do_log(s);
 		} else {
-			ha_alert("HTTP logging : out of memory.\n");
+			ha_alert("HTTP logging : OOM.\n");
 		}
 	}
 
@@ -3140,7 +3140,7 @@ static void http_manage_client_side_cookies(struct stream *s, struct channel *re
 				int log_len = val_end - att_beg;
 
 				if ((txn->cli_cookie = pool_alloc(pool_head_capture)) == NULL) {
-					ha_alert("HTTP logging : out of memory.\n");
+					ha_alert("HTTP logging : OOM.\n");
 				} else {
 					if (log_len > sess->fe->capture_len)
 						log_len = sess->fe->capture_len;
@@ -3545,7 +3545,7 @@ static void http_manage_server_side_cookies(struct stream *s, struct channel *re
 			    memcmp(att_beg, sess->fe->capture_name, sess->fe->capture_namelen) == 0) {
 				int log_len = val_end - att_beg;
 				if ((txn->srv_cookie = pool_alloc(pool_head_capture)) == NULL) {
-					ha_alert("HTTP logging : out of memory.\n");
+					ha_alert("HTTP logging : OOM.\n");
 				}
 				else {
 					if (log_len > sess->fe->capture_len)
@@ -4864,7 +4864,7 @@ static void http_capture_headers(struct htx *htx, char **cap, struct cap_hdr *ca
 						pool_alloc(h->pool);
 
 				if (cap[h->index] == NULL) {
-					ha_alert("HTTP capture : out of memory.\n");
+					ha_alert("HTTP capture : OOM.\n");
 					break;
 				}
 

--- a/src/http_client.c
+++ b/src/http_client.c
@@ -347,7 +347,7 @@ struct appctx *httpclient_start(struct httpclient *hc)
 
 	sess = session_new(httpclient_proxy, NULL, &appctx->obj_type);
 	if (!sess) {
-		ha_alert("httpclient: out of memory in %s:%d.\n", __FUNCTION__, __LINE__);
+		ha_alert("httpclient: OOM in %s:%d.\n", __FUNCTION__, __LINE__);
 		goto out_free_appctx;
 	}
 	if ((s = stream_new(sess, &appctx->obj_type, &BUF_NULL)) == NULL) {
@@ -689,7 +689,7 @@ static int httpclient_init()
 	httpclient_srv_raw = new_server(httpclient_proxy);
 	if (!httpclient_srv_raw) {
 		err_code |= ERR_ALERT | ERR_FATAL;
-		memprintf(&errmsg, "out of memory.");
+		memprintf(&errmsg, "OOM.");
 		goto err;
 	}
 
@@ -704,7 +704,7 @@ static int httpclient_init()
 	/* SSL HTTP server */
 	httpclient_srv_ssl = new_server(httpclient_proxy);
 	if (!httpclient_srv_ssl) {
-		memprintf(&errmsg, "out of memory.");
+		memprintf(&errmsg, "OOM.");
 		err_code |= ERR_ALERT | ERR_FATAL;
 		goto err;
 	}

--- a/src/http_htx.c
+++ b/src/http_htx.c
@@ -1161,7 +1161,7 @@ struct buffer *http_load_errorfile(const char *file, char **errmsg)
 
 	err = malloc(errlen);
 	if (!err) {
-		memprintf(errmsg, "out of memory.");
+		memprintf(errmsg, "OOM.");
 		goto out;
 	}
 
@@ -1174,12 +1174,12 @@ struct buffer *http_load_errorfile(const char *file, char **errmsg)
 	/* Create the node corresponding to the error file */
 	http_errmsg = calloc(1, sizeof(*http_errmsg));
 	if (!http_errmsg) {
-		memprintf(errmsg, "out of memory.");
+		memprintf(errmsg, "OOM.");
 		goto out;
 	}
 	http_errmsg->node.key = strdup(file);
 	if (!http_errmsg->node.key) {
-		memprintf(errmsg, "out of memory.");
+		memprintf(errmsg, "OOM.");
 		free(http_errmsg);
 		goto out;
 	}
@@ -1225,12 +1225,12 @@ struct buffer *http_load_errormsg(const char *key, const struct ist msg, char **
 	/* Create the node corresponding to the error file */
 	http_errmsg = calloc(1, sizeof(*http_errmsg));
 	if (!http_errmsg) {
-		memprintf(errmsg, "out of memory.");
+		memprintf(errmsg, "OOM.");
 		goto out;
 	}
 	http_errmsg->node.key = strdup(key);
 	if (!http_errmsg->node.key) {
-		memprintf(errmsg, "out of memory.");
+		memprintf(errmsg, "OOM.");
 		free(http_errmsg);
 		goto out;
 	}
@@ -1300,7 +1300,7 @@ struct buffer *http_parse_errorloc(int errloc, int status, const char *url, char
 		if (http_err_codes[rc] == status) {
 			/*  Create the error key */
 			if (!memprintf(&key, "errorloc%d %s", errloc, url)) {
-				memprintf(errmsg, "out of memory.");
+				memprintf(errmsg, "OOM.");
 				goto out;
 			}
 			/* Create the error message */
@@ -1308,7 +1308,7 @@ struct buffer *http_parse_errorloc(int errloc, int status, const char *url, char
 			errlen = strlen(msg) + strlen(url) + 5;
 			err = malloc(errlen);
 			if (!err) {
-				memprintf(errmsg, "out of memory.");
+				memprintf(errmsg, "OOM.");
 				goto out;
 			}
 			errlen = snprintf(err, errlen, "%s%s\r\n\r\n", msg, url);
@@ -1397,7 +1397,7 @@ struct http_reply *http_parse_http_reply(const char **args, int *orig_arg, struc
 
 	reply = calloc(1, sizeof(*reply));
 	if (!reply) {
-		memprintf(errmsg, "out of memory");
+		memprintf(errmsg, "OOM");
 		goto error;
 	}
 	LIST_INIT(&reply->hdrs);
@@ -1449,7 +1449,7 @@ struct http_reply *http_parse_http_reply(const char **args, int *orig_arg, struc
 			}
 			reply->body.http_errors = strdup(args[cur_arg]);
 			if (!reply->body.http_errors) {
-				memprintf(errmsg, "out of memory");
+				memprintf(errmsg, "OOM");
 				goto error;
 			}
 			reply->type = HTTP_REPLY_ERRFILES;
@@ -1530,7 +1530,7 @@ struct http_reply *http_parse_http_reply(const char **args, int *orig_arg, struc
 			obj = strdup(args[cur_arg]);
 			objlen = strlen(args[cur_arg]);
 			if (!obj) {
-				memprintf(errmsg, "out of memory");
+				memprintf(errmsg, "OOM");
 				goto error;
 			}
 			reply->type = HTTP_REPLY_RAW;
@@ -1603,14 +1603,14 @@ struct http_reply *http_parse_http_reply(const char **args, int *orig_arg, struc
 			}
 			hdr = calloc(1, sizeof(*hdr));
 			if (!hdr) {
-				memprintf(errmsg, "'%s' : out of memory", args[cur_arg-1]);
+				memprintf(errmsg, "'%s' : OOM", args[cur_arg-1]);
 				goto error;
 			}
 			LIST_APPEND(&reply->hdrs, &hdr->list);
 			LIST_INIT(&hdr->value);
 			hdr->name = ist(strdup(args[cur_arg]));
 			if (!isttest(hdr->name)) {
-				memprintf(errmsg, "out of memory");
+				memprintf(errmsg, "OOM");
 				goto error;
 			}
 			if (!parse_logformat_string(args[cur_arg+1], px, &hdr->value, LOG_OPT_HTTP, cap, errmsg))
@@ -1849,7 +1849,7 @@ static int proxy_parse_errorloc(char **args, int section, struct proxy *curpx,
 
 	reply = calloc(1, sizeof(*reply));
 	if (!reply) {
-		memprintf(errmsg, "%s : out of memory.", args[0]);
+		memprintf(errmsg, "%s : OOM.", args[0]);
 		ret = -1;
 		goto out;
 	}
@@ -1862,7 +1862,7 @@ static int proxy_parse_errorloc(char **args, int section, struct proxy *curpx,
 
 	conf_err = calloc(1, sizeof(*conf_err));
 	if (!conf_err) {
-		memprintf(errmsg, "%s : out of memory.", args[0]);
+		memprintf(errmsg, "%s : OOM.", args[0]);
 		free(reply);
 		ret = -1;
 		goto out;
@@ -1915,7 +1915,7 @@ static int proxy_parse_errorfile(char **args, int section, struct proxy *curpx,
 
 	reply = calloc(1, sizeof(*reply));
 	if (!reply) {
-		memprintf(errmsg, "%s : out of memory.", args[0]);
+		memprintf(errmsg, "%s : OOM.", args[0]);
 		ret = -1;
 		goto out;
 	}
@@ -1928,7 +1928,7 @@ static int proxy_parse_errorfile(char **args, int section, struct proxy *curpx,
 
 	conf_err = calloc(1, sizeof(*conf_err));
 	if (!conf_err) {
-		memprintf(errmsg, "%s : out of memory.", args[0]);
+		memprintf(errmsg, "%s : OOM.", args[0]);
 		free(reply);
 		ret = -1;
 		goto out;
@@ -1971,7 +1971,7 @@ static int proxy_parse_errorfiles(char **args, int section, struct proxy *curpx,
 	name = strdup(args[1]);
 	conf_err = calloc(1, sizeof(*conf_err));
 	if (!name || !conf_err) {
-		memprintf(err, "%s : out of memory.", args[0]);
+		memprintf(err, "%s : OOM.", args[0]);
 		goto error;
 	}
 	conf_err->type = 0;
@@ -2053,7 +2053,7 @@ static int proxy_parse_http_error(char **args, int section, struct proxy *curpx,
 
 	conf_err = calloc(1, sizeof(*conf_err));
 	if (!conf_err) {
-		memprintf(errmsg, "%s : out of memory.", args[0]);
+		memprintf(errmsg, "%s : OOM.", args[0]);
 		goto error;
 	}
 	if (reply->type == HTTP_REPLY_ERRFILES) {
@@ -2179,7 +2179,7 @@ int proxy_dup_default_conf_errors(struct proxy *curpx, const struct proxy *defpx
 	list_for_each_entry(conf_err, &defpx->conf.errors, list) {
 		new_conf_err = calloc(1, sizeof(*new_conf_err));
 		if (!new_conf_err) {
-			memprintf(errmsg, "unable to duplicate default errors (out of memory).");
+			memprintf(errmsg, "unable to duplicate default errors (OOM).");
 			goto out;
 		}
 		new_conf_err->type = conf_err->type;
@@ -2190,7 +2190,7 @@ int proxy_dup_default_conf_errors(struct proxy *curpx, const struct proxy *defpx
 		else {
 			new_conf_err->info.errorfiles.name = strdup(conf_err->info.errorfiles.name);
 			if (!new_conf_err->info.errorfiles.name) {
-				memprintf(errmsg, "unable to duplicate default errors (out of memory).");
+				memprintf(errmsg, "unable to duplicate default errors (OOM).");
 				goto out;
 			}
 			memcpy(&new_conf_err->info.errorfiles.status, &conf_err->info.errorfiles.status,
@@ -2262,7 +2262,7 @@ static int cfg_parse_http_errors(const char *file, int linenum, char **args, int
 		}
 
 		if ((curr_errs = calloc(1, sizeof(*curr_errs))) == NULL) {
-			ha_alert("parsing [%s:%d] : out of memory.\n", file, linenum);
+			ha_alert("parsing [%s:%d] : OOM.\n", file, linenum);
 			err_code |= ERR_ALERT | ERR_ABORT;
 			goto out;
 		}
@@ -2298,7 +2298,7 @@ static int cfg_parse_http_errors(const char *file, int linenum, char **args, int
 
 		reply = calloc(1, sizeof(*reply));
 		if (!reply) {
-			ha_alert("parsing [%s:%d] : %s : out of memory.\n", file, linenum, args[0]);
+			ha_alert("parsing [%s:%d] : %s : OOM.\n", file, linenum, args[0]);
 			err_code |= ERR_ALERT | ERR_FATAL;
 			goto out;
 		}

--- a/src/http_rules.c
+++ b/src/http_rules.c
@@ -82,7 +82,7 @@ struct act_rule *parse_http_req_cond(const char **args, const char *file, int li
 
 	rule = calloc(1, sizeof(*rule));
 	if (!rule) {
-		ha_alert("parsing [%s:%d]: out of memory.\n", file, linenum);
+		ha_alert("parsing [%s:%d]: OOM.\n", file, linenum);
 		goto out_err;
 	}
 	rule->from = ACT_F_HTTP_REQ;
@@ -161,7 +161,7 @@ struct act_rule *parse_http_res_cond(const char **args, const char *file, int li
 
 	rule = calloc(1, sizeof(*rule));
 	if (!rule) {
-		ha_alert("parsing [%s:%d]: out of memory.\n", file, linenum);
+		ha_alert("parsing [%s:%d]: OOM.\n", file, linenum);
 		goto out_err;
 	}
 	rule->from = ACT_F_HTTP_RES;
@@ -241,7 +241,7 @@ struct act_rule *parse_http_after_res_cond(const char **args, const char *file, 
 
 	rule = calloc(1, sizeof(*rule));
 	if (!rule) {
-		ha_alert("parsing [%s:%d]: out of memory.\n", file, linenum);
+		ha_alert("parsing [%s:%d]: OOM.\n", file, linenum);
 		goto out_err;
 	}
 	rule->from = ACT_F_HTTP_RES;
@@ -412,7 +412,7 @@ struct redirect_rule *http_parse_redirect_rule(const char *file, int linenum, st
 
 	rule = calloc(1, sizeof(*rule));
 	if (!rule) {
-		memprintf(errmsg, "parsing [%s:%d]: out of memory.", file, linenum);
+		memprintf(errmsg, "parsing [%s:%d]: OOM.", file, linenum);
 		return NULL;
 	}
 	rule->cond = cond;

--- a/src/init.c
+++ b/src/init.c
@@ -80,7 +80,7 @@ void hap_register_post_check(int (*fct)())
 
 	b = calloc(1, sizeof(*b));
 	if (!b) {
-		fprintf(stderr, "out of memory\n");
+		fprintf(stderr, "OOM\n");
 		exit(1);
 	}
 	b->fct = fct;
@@ -96,7 +96,7 @@ void hap_register_post_proxy_check(int (*fct)(struct proxy *))
 
 	b = calloc(1, sizeof(*b));
 	if (!b) {
-		fprintf(stderr, "out of memory\n");
+		fprintf(stderr, "OOM\n");
 		exit(1);
 	}
 	b->fct = fct;
@@ -112,7 +112,7 @@ void hap_register_post_server_check(int (*fct)(struct server *))
 
 	b = calloc(1, sizeof(*b));
 	if (!b) {
-		fprintf(stderr, "out of memory\n");
+		fprintf(stderr, "OOM\n");
 		exit(1);
 	}
 	b->fct = fct;
@@ -128,7 +128,7 @@ void hap_register_post_deinit(void (*fct)())
 
 	b = calloc(1, sizeof(*b));
 	if (!b) {
-		fprintf(stderr, "out of memory\n");
+		fprintf(stderr, "OOM\n");
 		exit(1);
 	}
 	b->fct = fct;
@@ -144,7 +144,7 @@ void hap_register_proxy_deinit(void (*fct)(struct proxy *))
 
 	b = calloc(1, sizeof(*b));
 	if (!b) {
-		fprintf(stderr, "out of memory\n");
+		fprintf(stderr, "OOM\n");
 		exit(1);
 	}
 	b->fct = fct;
@@ -160,7 +160,7 @@ void hap_register_server_deinit(void (*fct)(struct server *))
 
 	b = calloc(1, sizeof(*b));
 	if (!b) {
-		fprintf(stderr, "out of memory\n");
+		fprintf(stderr, "OOM\n");
 		exit(1);
 	}
 	b->fct = fct;
@@ -174,7 +174,7 @@ void hap_register_per_thread_alloc(int (*fct)())
 
 	b = calloc(1, sizeof(*b));
 	if (!b) {
-		fprintf(stderr, "out of memory\n");
+		fprintf(stderr, "OOM\n");
 		exit(1);
 	}
 	b->fct = fct;
@@ -188,7 +188,7 @@ void hap_register_per_thread_init(int (*fct)())
 
 	b = calloc(1, sizeof(*b));
 	if (!b) {
-		fprintf(stderr, "out of memory\n");
+		fprintf(stderr, "OOM\n");
 		exit(1);
 	}
 	b->fct = fct;
@@ -202,7 +202,7 @@ void hap_register_per_thread_deinit(void (*fct)())
 
 	b = calloc(1, sizeof(*b));
 	if (!b) {
-		fprintf(stderr, "out of memory\n");
+		fprintf(stderr, "OOM\n");
 		exit(1);
 	}
 	b->fct = fct;
@@ -216,7 +216,7 @@ void hap_register_per_thread_free(void (*fct)())
 
 	b = calloc(1, sizeof(*b));
 	if (!b) {
-		fprintf(stderr, "out of memory\n");
+		fprintf(stderr, "OOM\n");
 		exit(1);
 	}
 	b->fct = fct;

--- a/src/listener.c
+++ b/src/listener.c
@@ -174,7 +174,7 @@ static int accept_queue_init()
 	for (i = 0; i < global.nbthread; i++) {
 		t = tasklet_new();
 		if (!t) {
-			ha_alert("Out of memory while initializing accept queue for thread %d\n", i);
+			ha_alert("OOM while initializing accept queue for thread %d\n", i);
 			return ERR_FATAL|ERR_ABORT;
 		}
 		t->tid = i;
@@ -628,7 +628,7 @@ int create_listeners(struct bind_conf *bc, const struct sockaddr_storage *ss,
 	for (port = portl; port <= porth; port++) {
 		l = calloc(1, sizeof(*l));
 		if (!l) {
-			memprintf(err, "out of memory");
+			memprintf(err, "OOM");
 			return 0;
 		}
 		l->obj_type = OBJ_TYPE_LISTENER;
@@ -1136,7 +1136,7 @@ static int listener_queue_init()
 {
 	global_listener_queue_task = task_new(MAX_THREADS_MASK);
 	if (!global_listener_queue_task) {
-		ha_alert("Out of memory when initializing global listener queue\n");
+		ha_alert("OOM when initializing global listener queue\n");
 		return ERR_FATAL|ERR_ABORT;
 	}
 	/* very simple initialization, users will queue the task if needed */

--- a/src/log.c
+++ b/src/log.c
@@ -312,7 +312,7 @@ int parse_logformat_var(char *arg, int arg_len, char *var, int var_len, struct p
 			if (logformat_keywords[j].mode != PR_MODE_HTTP || curproxy->mode == PR_MODE_HTTP) {
 				node = calloc(1, sizeof(*node));
 				if (!node) {
-					memprintf(err, "out of memory error");
+					memprintf(err, "OOM error");
 					goto error_free;
 				}
 				node->type = logformat_keywords[j].type;
@@ -374,7 +374,7 @@ int add_to_logformat_list(char *start, char *end, int type, struct list *list_fo
 	if (type == LF_TEXT) { /* type text */
 		struct logformat_node *node = calloc(1, sizeof(*node));
 		if (!node) {
-			memprintf(err, "out of memory error");
+			memprintf(err, "OOM error");
 			return 0;
 		}
 		str = calloc(1, end - start + 1);
@@ -386,7 +386,7 @@ int add_to_logformat_list(char *start, char *end, int type, struct list *list_fo
 	} else if (type == LF_SEPARATOR) {
 		struct logformat_node *node = calloc(1, sizeof(*node));
 		if (!node) {
-			memprintf(err, "out of memory error");
+			memprintf(err, "OOM error");
 			return 0;
 		}
 		node->type = LOG_FMT_SEPARATOR;
@@ -423,7 +423,7 @@ int add_sample_to_logformat_list(char *text, char *arg, int arg_len, struct prox
 
 	node = calloc(1, sizeof(*node));
 	if (!node) {
-		memprintf(err, "out of memory error");
+		memprintf(err, "OOM error");
 		goto error_free;
 	}
 	node->type = LOG_FMT_EXPR;
@@ -502,7 +502,7 @@ int parse_logformat_string(const char *fmt, struct proxy *curproxy, struct list 
 
 	sp = str = backfmt = strdup(fmt);
 	if (!str) {
-		memprintf(err, "out of memory error");
+		memprintf(err, "OOM error");
 		return 0;
 	}
 	curproxy->to_log |= LW_INIT;
@@ -820,7 +820,7 @@ int parse_logsrv(char **args, struct list *logsrvs, int do_del, const char *file
 
 	logsrv = calloc(1, sizeof(*logsrv));
 	if (!logsrv) {
-		memprintf(err, "out of memory");
+		memprintf(err, "OOM");
 		goto error;
 	}
 
@@ -880,7 +880,7 @@ int parse_logsrv(char **args, struct list *logsrvs, int do_del, const char *file
 
 			smp_rgs = my_realloc2(smp_rgs, (smp_rgs_sz + 1) * sizeof *smp_rgs);
 			if (!smp_rgs) {
-				memprintf(err, "out of memory error");
+				memprintf(err, "OOM error");
 				goto error;
 			}
 
@@ -3785,7 +3785,7 @@ int cfg_parse_log_forward(const char *file, int linenum, char **args, int kwm)
 		bind_conf = bind_conf_alloc(cfg_log_forward, file, linenum,
 					    NULL, xprt_get(XPRT_RAW));
 		if (!bind_conf) {
-			ha_alert("parsing [%s:%d] : out of memory error.", file, linenum);
+			ha_alert("parsing [%s:%d] : OOM error.", file, linenum);
 			err_code |= ERR_ALERT | ERR_FATAL;
 			goto out;
 		}
@@ -3852,7 +3852,7 @@ int cfg_parse_log_forward(const char *file, int linenum, char **args, int kwm)
 		bind_conf = bind_conf_alloc(cfg_log_forward, file, linenum,
 		                            NULL, xprt_get(XPRT_RAW));
 		if (!bind_conf) {
-			ha_alert("parsing [%s:%d] : out of memory error.", file, linenum);
+			ha_alert("parsing [%s:%d] : OOM error.", file, linenum);
 			err_code |= ERR_ALERT | ERR_FATAL;
 			goto out;
 		}

--- a/src/mailers.c
+++ b/src/mailers.c
@@ -109,7 +109,7 @@ int init_email_alert(struct mailers *mls, struct proxy *p, char **err)
 	int                  i = 0;
 
 	if ((queues = calloc(mls->count, sizeof(*queues))) == NULL) {
-		memprintf(err, "out of memory while allocating mailer alerts queues");
+		memprintf(err, "OOM while allocating mailer alerts queues");
 		goto fail_no_queue;
 	}
 
@@ -134,7 +134,7 @@ int init_email_alert(struct mailers *mls, struct proxy *p, char **err)
 		check->port = get_host_port(&mailer->addr);
 
 		if ((t = task_new(MAX_THREADS_MASK)) == NULL) {
-			memprintf(err, "out of memory while allocating mailer alerts task");
+			memprintf(err, "OOM while allocating mailer alerts task");
 			goto error;
 		}
 
@@ -286,7 +286,7 @@ static void enqueue_email_alert(struct proxy *p, struct server *s, const char *m
 	for (i = 0, mailer = p->email_alert.mailers.m->mailer_list;
 	     i < p->email_alert.mailers.m->count; i++, mailer = mailer->next) {
 		if (!enqueue_one_email_alert(p, s, &p->email_alert.queues[i], msg)) {
-			ha_alert("Email alert [%s] could not be enqueued: out of memory\n", p->id);
+			ha_alert("Email alert [%s] could not be enqueued: OOM\n", p->id);
 			return;
 		}
 	}

--- a/src/map.c
+++ b/src/map.c
@@ -73,7 +73,7 @@ int map_parse_int(const char *text, struct sample_data *data)
 }
 
 /* This crete and initialize map descriptor.
- * Return NULL if out of memory error
+ * Return NULL if OOM error
  */
 static struct map_descriptor *map_create_descriptor(struct sample_conv *conv)
 {
@@ -107,7 +107,7 @@ int sample_load_map(struct arg *arg, struct sample_conv *conv,
 	/* create new map descriptor */
 	desc = map_create_descriptor(conv);
 	if (!desc) {
-		memprintf(err, "out of memory");
+		memprintf(err, "OOM");
 		return 0;
 	}
 
@@ -626,7 +626,7 @@ static int cli_parse_get_map(char **args, char *payload, struct appctx *appctx, 
 		appctx->ctx.map.chunk.size = appctx->ctx.map.chunk.data + 1;
 		appctx->ctx.map.chunk.area = strdup(args[3]);
 		if (!appctx->ctx.map.chunk.area)
-			return cli_err(appctx,  "Out of memory error.\n");
+			return cli_err(appctx,  "OOM error.\n");
 
 		return 0;
 	}

--- a/src/mux_h1.c
+++ b/src/mux_h1.c
@@ -3583,7 +3583,7 @@ static int add_hdr_case_adjust(const char *from, const char *to, char **err)
 	/* Create the entry and insert it in the tree */
 	entry = malloc(sizeof(*entry));
 	if (!entry) {
-		memprintf(err, "out of memory");
+		memprintf(err, "OOM");
 		return -1;
 	}
 
@@ -3593,7 +3593,7 @@ static int add_hdr_case_adjust(const char *from, const char *to, char **err)
 		free(entry->node.key);
 		istfree(&entry->name);
 		free(entry);
-		memprintf(err, "out of memory");
+		memprintf(err, "OOM");
 		return -1;
 	}
 	ebis_insert(&hdrs_map.map, &entry->node);

--- a/src/mworker-prog.c
+++ b/src/mworker-prog.c
@@ -148,7 +148,7 @@ int cfg_parse_program(const char *file, int linenum, char **args, int kwm)
 
 		ext_child = calloc(1, sizeof(*ext_child));
 		if (!ext_child) {
-			ha_alert("parsing [%s:%d] : out of memory.\n", file, linenum);
+			ha_alert("parsing [%s:%d] : OOM.\n", file, linenum);
 			err_code |= ERR_ALERT | ERR_ABORT;
 			goto error;
 		}
@@ -179,7 +179,7 @@ int cfg_parse_program(const char *file, int linenum, char **args, int kwm)
 
 		ext_child->id = strdup(args[1]);
 		if (!ext_child->id) {
-			ha_alert("parsing [%s:%d] : out of memory.\n", file, linenum);
+			ha_alert("parsing [%s:%d] : OOM.\n", file, linenum);
 			err_code |= ERR_ALERT | ERR_ABORT;
 			goto error;
 		}
@@ -202,7 +202,7 @@ int cfg_parse_program(const char *file, int linenum, char **args, int kwm)
 		ext_child->command = calloc(arg_nb+1, sizeof(*ext_child->command));
 
 		if (!ext_child->command) {
-			ha_alert("parsing [%s:%d] : out of memory.\n", file, linenum);
+			ha_alert("parsing [%s:%d] : OOM.\n", file, linenum);
 			err_code |= ERR_ALERT | ERR_ABORT;
 			goto error;
 		}
@@ -210,7 +210,7 @@ int cfg_parse_program(const char *file, int linenum, char **args, int kwm)
 		while (i < arg_nb) {
 			ext_child->command[i] = strdup(args[i+1]);
 			if (!ext_child->command[i]) {
-				ha_alert("parsing [%s:%d] : out of memory.\n", file, linenum);
+				ha_alert("parsing [%s:%d] : OOM.\n", file, linenum);
 				err_code |= ERR_ALERT | ERR_ABORT;
 				goto error;
 			}

--- a/src/mworker.c
+++ b/src/mworker.c
@@ -148,7 +148,7 @@ int mworker_env_to_proc_list()
 
 		child = calloc(1, sizeof(*child));
 		if (!child) {
-			ha_alert("Out of memory while trying to allocate a worker process structure.");
+			ha_alert("OOM while trying to allocate a worker process structure.");
 			return -1;
 		}
 

--- a/src/pattern.c
+++ b/src/pattern.c
@@ -1193,7 +1193,7 @@ int pat_idx_list_val(struct pattern_expr *expr, struct pattern *pat, char **err)
 	/* allocate pattern */
 	patl = calloc(1, sizeof(*patl));
 	if (!patl) {
-		memprintf(err, "out of memory while indexing pattern");
+		memprintf(err, "OOM while indexing pattern");
 		return 0;
 	}
 
@@ -1219,7 +1219,7 @@ int pat_idx_list_ptr(struct pattern_expr *expr, struct pattern *pat, char **err)
 	/* allocate pattern */
 	patl = calloc(1, sizeof(*patl));
 	if (!patl) {
-		memprintf(err, "out of memory while indexing pattern");
+		memprintf(err, "OOM while indexing pattern");
 		return 0;
 	}
 
@@ -1228,7 +1228,7 @@ int pat_idx_list_ptr(struct pattern_expr *expr, struct pattern *pat, char **err)
 	patl->pat.ptr.ptr = malloc(patl->pat.len);
 	if (!patl->pat.ptr.ptr) {
 		free(patl);
-		memprintf(err, "out of memory while indexing pattern");
+		memprintf(err, "OOM while indexing pattern");
 		return 0;
 	}
 	memcpy(patl->pat.ptr.ptr, pat->ptr.ptr, pat->len);
@@ -1252,7 +1252,7 @@ int pat_idx_list_str(struct pattern_expr *expr, struct pattern *pat, char **err)
 	/* allocate pattern */
 	patl = calloc(1, sizeof(*patl));
 	if (!patl) {
-		memprintf(err, "out of memory while indexing pattern");
+		memprintf(err, "OOM while indexing pattern");
 		return 0;
 	}
 
@@ -1261,7 +1261,7 @@ int pat_idx_list_str(struct pattern_expr *expr, struct pattern *pat, char **err)
 	patl->pat.ptr.str = malloc(patl->pat.len + 1);
 	if (!patl->pat.ptr.str) {
 		free(patl);
-		memprintf(err, "out of memory while indexing pattern");
+		memprintf(err, "OOM while indexing pattern");
 		return 0;
 	}
 	memcpy(patl->pat.ptr.ptr, pat->ptr.ptr, pat->len);
@@ -1286,7 +1286,7 @@ int pat_idx_list_reg_cap(struct pattern_expr *expr, struct pattern *pat, int cap
 	/* allocate pattern */
 	patl = calloc(1, sizeof(*patl));
 	if (!patl) {
-		memprintf(err, "out of memory while indexing pattern");
+		memprintf(err, "OOM while indexing pattern");
 		return 0;
 	}
 
@@ -1342,7 +1342,7 @@ int pat_idx_tree_ip(struct pattern_expr *expr, struct pattern *pat, char **err)
 			/* node memory allocation */
 			node = calloc(1, sizeof(*node) + 4);
 			if (!node) {
-				memprintf(err, "out of memory while loading pattern");
+				memprintf(err, "OOM while loading pattern");
 				return 0;
 			}
 
@@ -1373,7 +1373,7 @@ int pat_idx_tree_ip(struct pattern_expr *expr, struct pattern *pat, char **err)
 		/* IPv6 also can be indexed */
 		node = calloc(1, sizeof(*node) + 16);
 		if (!node) {
-			memprintf(err, "out of memory while loading pattern");
+			memprintf(err, "OOM while loading pattern");
 			return 0;
 		}
 
@@ -1421,7 +1421,7 @@ int pat_idx_tree_str(struct pattern_expr *expr, struct pattern *pat, char **err)
 	/* node memory allocation */
 	node = calloc(1, sizeof(*node) + len);
 	if (!node) {
-		memprintf(err, "out of memory while loading pattern");
+		memprintf(err, "OOM while loading pattern");
 		return 0;
 	}
 
@@ -1465,7 +1465,7 @@ int pat_idx_tree_pfx(struct pattern_expr *expr, struct pattern *pat, char **err)
 	/* node memory allocation */
 	node = calloc(1, sizeof(*node) + len + 1);
 	if (!node) {
-		memprintf(err, "out of memory while loading pattern");
+		memprintf(err, "OOM while loading pattern");
 		return 0;
 	}
 
@@ -1710,7 +1710,7 @@ static inline int pat_ref_set_elt(struct pat_ref *ref, struct pat_ref_elt *elt,
 	/* Modify pattern from reference. */
 	sample = strdup(value);
 	if (!sample) {
-		memprintf(err, "out of memory error");
+		memprintf(err, "OOM error");
 		return 0;
 	}
 	/* Load sample in each reference. All the conversions are tested
@@ -2009,7 +2009,7 @@ struct pat_ref_elt *pat_ref_load(struct pat_ref *ref, unsigned int gen,
 		if (!pat_ref_commit_elt(ref, elt, err))
 			elt = NULL;
 	} else
-		memprintf(err, "out of memory error");
+		memprintf(err, "OOM error");
 
 	return elt;
 }
@@ -2136,7 +2136,7 @@ struct pattern_expr *pattern_new_expr(struct pattern_head *head, struct pat_ref 
 	/* Memory and initialization of the chain element. */
 	list = calloc(1, sizeof(*list));
 	if (!list) {
-		memprintf(err, "out of memory");
+		memprintf(err, "OOM");
 		return NULL;
 	}
 
@@ -2163,7 +2163,7 @@ struct pattern_expr *pattern_new_expr(struct pattern_head *head, struct pat_ref 
 		expr = calloc(1, sizeof(*expr));
 		if (!expr) {
 			free(list);
-			memprintf(err, "out of memory");
+			memprintf(err, "OOM");
 			return NULL;
 		}
 
@@ -2292,7 +2292,7 @@ int pat_ref_read_from_file_smp(struct pat_ref *ref, const char *filename, char *
 
 		/* insert values */
 		if (!pat_ref_append(ref, key_beg, value_beg, line)) {
-			memprintf(err, "out of memory");
+			memprintf(err, "OOM");
 			goto out_close;
 		}
 	}
@@ -2354,7 +2354,7 @@ int pat_ref_read_from_file(struct pat_ref *ref, const char *filename, char **err
 			continue;
 
 		if (!pat_ref_append(ref, arg, NULL, line)) {
-			memprintf(err, "out of memory when loading patterns from file <%s>", filename);
+			memprintf(err, "OOM when loading patterns from file <%s>", filename);
 			goto out_close;
 		}
 	}
@@ -2391,7 +2391,7 @@ int pattern_read_from_file(struct pattern_head *head, unsigned int refflags,
 
 		ref = pat_ref_new(filename, trash.area, refflags);
 		if (!ref) {
-			memprintf(err, "out of memory");
+			memprintf(err, "OOM");
 			return 0;
 		}
 
@@ -2438,7 +2438,7 @@ int pattern_read_from_file(struct pattern_head *head, unsigned int refflags,
 		free(ref->display);
 		ref->display = strdup(trash.area);
 		if (!ref->display) {
-			memprintf(err, "out of memory");
+			memprintf(err, "OOM");
 			return 0;
 		}
 
@@ -2645,7 +2645,7 @@ int pattern_finalize_config(void)
 
 	arr = calloc(len, sizeof(*arr));
 	if (arr == NULL) {
-		ha_alert("Out of memory error.\n");
+		ha_alert("OOM error.\n");
 		return ERR_ALERT | ERR_FATAL;
 	}
 

--- a/src/peers.c
+++ b/src/peers.c
@@ -3192,7 +3192,7 @@ static struct appctx *peer_session_create(struct peers *peers, struct peer *peer
 
 	sess = session_new(p, NULL, &appctx->obj_type);
 	if (!sess) {
-		ha_alert("out of memory in peer_session_create().\n");
+		ha_alert("OOM in peer_session_create().\n");
 		goto out_free_appctx;
 	}
 

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -767,7 +767,7 @@ static int proxy_parse_declare(char **args, int section, struct proxy *curpx,
 		/* register the capture. */
 		hdr = calloc(1, sizeof(*hdr));
 		if (!hdr) {
-			memprintf(err, "proxy '%s': out of memory while registering a capture", curpx->id);
+			memprintf(err, "proxy '%s': OOM while registering a capture", curpx->id);
 			return -1;
 		}
 		hdr->name = NULL; /* not a header capture */
@@ -1495,7 +1495,7 @@ struct proxy *alloc_new_proxy(const char *name, unsigned int cap, char **errmsg)
 	struct proxy *curproxy;
 
 	if ((curproxy = calloc(1, sizeof(*curproxy))) == NULL) {
-		memprintf(errmsg, "proxy '%s': out of memory", name);
+		memprintf(errmsg, "proxy '%s': OOM", name);
 		goto fail;
 	}
 
@@ -1713,7 +1713,7 @@ static int proxy_defproxy_cpy(struct proxy *curproxy, const struct proxy *defpro
 		struct logsrv *node = malloc(sizeof(*node));
 
 		if (!node) {
-			memprintf(errmsg, "proxy '%s': out of memory", curproxy->id);
+			memprintf(errmsg, "proxy '%s': OOM", curproxy->id);
 			return 1;
 		}
 		memcpy(node, tmplogsrv, sizeof(struct logsrv));
@@ -1738,7 +1738,7 @@ static int proxy_defproxy_cpy(struct proxy *curproxy, const struct proxy *defpro
 		const struct ist copy = istdup(defproxy->header_unique_id);
 
 		if (!isttest(copy)) {
-			memprintf(errmsg, "proxy '%s': out of memory for unique-id-header", curproxy->id);
+			memprintf(errmsg, "proxy '%s': OOM for unique-id-header", curproxy->id);
 			return 1;
 		}
 		curproxy->header_unique_id = copy;
@@ -1748,7 +1748,7 @@ static int proxy_defproxy_cpy(struct proxy *curproxy, const struct proxy *defpro
 	if (defproxy->comp != NULL) {
 		curproxy->comp = calloc(1, sizeof(*curproxy->comp));
 		if (!curproxy->comp) {
-			memprintf(errmsg, "proxy '%s': out of memory for default compression options", curproxy->id);
+			memprintf(errmsg, "proxy '%s': OOM for default compression options", curproxy->id);
 			return 1;
 		}
 		curproxy->comp->algos = defproxy->comp->algos;
@@ -2045,7 +2045,7 @@ static void do_soft_stop_now()
 			task_schedule(task, tick_add(now_ms, global.hard_stop_after));
 		}
 		else {
-			ha_alert("out of memory trying to allocate the hard-stop task.\n");
+			ha_alert("OOM when trying to allocate the hard-stop task.\n");
 		}
 	}
 
@@ -2086,7 +2086,7 @@ void soft_stop(void)
 			return;
 		}
 		else {
-			ha_alert("out of memory trying to allocate the stop-stop task, stopping now.\n");
+			ha_alert("OOM when trying to allocate the stop-stop task, stopping now.\n");
 		}
 	}
 

--- a/src/resolvers.c
+++ b/src/resolvers.c
@@ -199,7 +199,7 @@ struct resolv_srvrq *new_resolv_srvrq(struct server *srv, char *fqdn)
 	}
 
 	if ((srvrq = calloc(1, sizeof(*srvrq))) == NULL) {
-		ha_alert("%s '%s', server '%s': out of memory\n",
+		ha_alert("%s '%s', server '%s': OOM\n",
 			 proxy_type_str(px), px->id, srv->id);
 		goto err;
 	}
@@ -209,7 +209,7 @@ struct resolv_srvrq *new_resolv_srvrq(struct server *srv, char *fqdn)
 	srvrq->hostname_dn     = strdup(trash.area);
 	srvrq->hostname_dn_len = hostname_dn_len;
 	if (!srvrq->name || !srvrq->hostname_dn) {
-		ha_alert("%s '%s', server '%s': out of memory\n",
+		ha_alert("%s '%s', server '%s': OOM\n",
 			 proxy_type_str(px), px->id, srv->id);
 		goto err;
 	}
@@ -2413,7 +2413,7 @@ static int resolvers_finalize_config(void)
 
 		/* Create the task associated to the resolvers section */
 		if ((t = task_new(MAX_THREADS_MASK)) == NULL) {
-			ha_alert("resolvers '%s' : out of memory.\n", resolvers->id);
+			ha_alert("resolvers '%s' : OOM.\n", resolvers->id);
 			err_code |= (ERR_ALERT|ERR_ABORT);
 			goto err;
 		}
@@ -3088,7 +3088,7 @@ int cfg_parse_resolvers(const char *file, int linenum, char **args, int kwm)
 		}
 
 		if ((curr_resolvers = calloc(1, sizeof(*curr_resolvers))) == NULL) {
-			ha_alert("parsing [%s:%d] : out of memory.\n", file, linenum);
+			ha_alert("parsing [%s:%d] : OOM.\n", file, linenum);
 			err_code |= ERR_ALERT | ERR_ABORT;
 			goto out;
 		}
@@ -3096,7 +3096,7 @@ int cfg_parse_resolvers(const char *file, int linenum, char **args, int kwm)
                 /* allocate new proxy to tcp servers */
                 p = calloc(1, sizeof *p);
                 if (!p) {
-                        ha_alert("parsing [%s:%d] : out of memory.\n", file, linenum);
+                        ha_alert("parsing [%s:%d] : OOM.\n", file, linenum);
                         err_code |= ERR_ALERT | ERR_FATAL;
                         goto out;
                 }
@@ -3172,7 +3172,7 @@ int cfg_parse_resolvers(const char *file, int linenum, char **args, int kwm)
 		}
 
 		if ((newnameserver = calloc(1, sizeof(*newnameserver))) == NULL) {
-			ha_alert("parsing [%s:%d] : out of memory.\n", file, linenum);
+			ha_alert("parsing [%s:%d] : OOM.\n", file, linenum);
 			err_code |= ERR_ALERT | ERR_ABORT;
 			goto out;
 		}
@@ -3186,25 +3186,25 @@ int cfg_parse_resolvers(const char *file, int linenum, char **args, int kwm)
 			}
 
 			if (dns_stream_init(newnameserver, curr_resolvers->px->srv) < 0) {
-				ha_alert("parsing [%s:%d] : out of memory.\n", file, linenum);
+				ha_alert("parsing [%s:%d] : OOM.\n", file, linenum);
 				err_code |= ERR_ALERT|ERR_ABORT;
 				goto out;
 			}
 		}
 		else if (dns_dgram_init(newnameserver, sk) < 0) {
-			ha_alert("parsing [%s:%d] : out of memory.\n", file, linenum);
+			ha_alert("parsing [%s:%d] : OOM.\n", file, linenum);
 			err_code |= ERR_ALERT | ERR_ABORT;
 			goto out;
 		}
 
 		if ((newnameserver->conf.file = strdup(file)) == NULL) {
-			ha_alert("parsing [%s:%d] : out of memory.\n", file, linenum);
+			ha_alert("parsing [%s:%d] : OOM.\n", file, linenum);
 			err_code |= ERR_ALERT | ERR_ABORT;
 			goto out;
 		}
 
 		if ((newnameserver->id = strdup(args[1])) == NULL) {
-			ha_alert("parsing [%s:%d] : out of memory.\n", file, linenum);
+			ha_alert("parsing [%s:%d] : OOM.\n", file, linenum);
 			err_code |= ERR_ALERT | ERR_ABORT;
 			goto out;
 		}
@@ -3227,7 +3227,7 @@ int cfg_parse_resolvers(const char *file, int linenum, char **args, int kwm)
 		int duplicate_name = 0;
 
 		if ((resolv_line = malloc(sizeof(*resolv_line) * LINESIZE)) == NULL) {
-			ha_alert("parsing [%s:%d] : out of memory.\n",
+			ha_alert("parsing [%s:%d] : OOM.\n",
 				 file, linenum);
 			err_code |= ERR_ALERT | ERR_FATAL;
 			goto resolv_out;
@@ -3242,7 +3242,7 @@ int cfg_parse_resolvers(const char *file, int linenum, char **args, int kwm)
 
 		sk = calloc(1, sizeof(*sk));
 		if (sk == NULL) {
-			ha_alert("parsing [/etc/resolv.conf:%d] : out of memory.\n",
+			ha_alert("parsing [/etc/resolv.conf:%d] : OOM.\n",
 				 resolv_linenum);
 			err_code |= ERR_ALERT | ERR_FATAL;
 			goto resolv_out;
@@ -3296,13 +3296,13 @@ int cfg_parse_resolvers(const char *file, int linenum, char **args, int kwm)
 			}
 
 			if ((newnameserver = calloc(1, sizeof(*newnameserver))) == NULL) {
-				ha_alert("parsing [/etc/resolv.conf:%d] : out of memory.\n", resolv_linenum);
+				ha_alert("parsing [/etc/resolv.conf:%d] : OOM.\n", resolv_linenum);
 				err_code |= ERR_ALERT | ERR_FATAL;
 				goto resolv_out;
 			}
 
 			if (dns_dgram_init(newnameserver, sk) < 0) {
-				ha_alert("parsing [/etc/resolv.conf:%d] : out of memory.\n", resolv_linenum);
+				ha_alert("parsing [/etc/resolv.conf:%d] : OOM.\n", resolv_linenum);
 				err_code |= ERR_ALERT | ERR_FATAL;
 				free(newnameserver);
 				goto resolv_out;
@@ -3310,7 +3310,7 @@ int cfg_parse_resolvers(const char *file, int linenum, char **args, int kwm)
 
 			newnameserver->conf.file = strdup("/etc/resolv.conf");
 			if (newnameserver->conf.file == NULL) {
-				ha_alert("parsing [/etc/resolv.conf:%d] : out of memory.\n", resolv_linenum);
+				ha_alert("parsing [/etc/resolv.conf:%d] : OOM.\n", resolv_linenum);
 				err_code |= ERR_ALERT | ERR_FATAL;
 				free(newnameserver);
 				goto resolv_out;
@@ -3318,7 +3318,7 @@ int cfg_parse_resolvers(const char *file, int linenum, char **args, int kwm)
 
 			newnameserver->id = strdup(address);
 			if (newnameserver->id == NULL) {
-				ha_alert("parsing [/etc/resolv.conf:%d] : out of memory.\n", resolv_linenum);
+				ha_alert("parsing [/etc/resolv.conf:%d] : OOM.\n", resolv_linenum);
 				err_code |= ERR_ALERT | ERR_FATAL;
 				free((char *)newnameserver->conf.file);
 				free(newnameserver);

--- a/src/server.c
+++ b/src/server.c
@@ -1064,7 +1064,7 @@ static int srv_parse_source(char **args, int *cur_arg,
 
 		newsrv->conn_src.sport_range = port_range_alloc_range(port_high - port_low + 1);
 		if (!newsrv->conn_src.sport_range) {
-			ha_alert("Server '%s': Out of memory (sport_range)\n", args[0]);
+			ha_alert("Server '%s': OOM (sport_range)\n", args[0]);
 			goto err;
 		}
 		for (i = 0; i < newsrv->conn_src.sport_range->size; i++)
@@ -1104,7 +1104,7 @@ static int srv_parse_source(char **args, int *cur_arg,
 				free(newsrv->conn_src.bind_hdr_name);
 				newsrv->conn_src.bind_hdr_name = calloc(1, end - name + 1);
 				if (!newsrv->conn_src.bind_hdr_name) {
-					ha_alert("Server '%s': Out of memory (bind_hdr_name)\n", args[0]);
+					ha_alert("Server '%s': OOM (bind_hdr_name)\n", args[0]);
 					goto err;
 				}
 				newsrv->conn_src.bind_hdr_len = end - name;
@@ -2469,7 +2469,7 @@ static int _srv_parse_init(struct server **srv, char **args, int *cur_arg,
 
 		*srv = newsrv = new_server(curproxy);
 		if (!newsrv) {
-			ha_alert("out of memory.\n");
+			ha_alert("OOM.\n");
 			err_code |= ERR_ALERT | ERR_ABORT;
 			goto out;
 		}

--- a/src/sink.c
+++ b/src/sink.c
@@ -650,7 +650,7 @@ static struct appctx *sink_forward_session_create(struct sink *sink, struct sink
 
 	sess = session_new(p, NULL, &appctx->obj_type);
 	if (!sess) {
-		ha_alert("out of memory in peer_session_create().\n");
+		ha_alert("OOM in peer_session_create().\n");
 		goto out_free_appctx;
 	}
 
@@ -784,7 +784,7 @@ int cfg_parse_ring(const char *file, int linenum, char **args, int kwm)
 		/* allocate new proxy to handle forwards */
 		p = calloc(1, sizeof *p);
 		if (!p) {
-			ha_alert("parsing [%s:%d] : out of memory.\n", file, linenum);
+			ha_alert("parsing [%s:%d] : OOM.\n", file, linenum);
 			err_code |= ERR_ALERT | ERR_FATAL;
 			goto err;
 		}

--- a/src/ssl_sock.c
+++ b/src/ssl_sock.c
@@ -537,7 +537,7 @@ int ssl_sock_register_msg_callback(ssl_sock_msg_callback_func func)
 
 	cbk = calloc(1, sizeof(*cbk));
 	if (!cbk) {
-		ha_alert("out of memory in ssl_sock_register_msg_callback().\n");
+		ha_alert("OOM in ssl_sock_register_msg_callback().\n");
 		return 0;
 	}
 
@@ -4803,7 +4803,7 @@ int ssl_sock_prepare_srv_ctx(struct server *srv)
 	/* Initiate SSL context for current server */
 	if (!srv->ssl_ctx.reused_sess) {
 		if ((srv->ssl_ctx.reused_sess = calloc(1, global.nbthread*sizeof(*srv->ssl_ctx.reused_sess))) == NULL) {
-			ha_alert("out of memory.\n");
+			ha_alert("OOM.\n");
 			cfgerr++;
 			return cfgerr;
 		}

--- a/src/tcp_rules.c
+++ b/src/tcp_rules.c
@@ -827,7 +827,7 @@ static int tcp_parse_request_rule(char **args, int arg, int section_type,
 
 		hdr = calloc(1, sizeof(*hdr));
 		if (!hdr) {
-			memprintf(err, "parsing [%s:%d] : out of memory", file, line);
+			memprintf(err, "parsing [%s:%d] : OOM", file, line);
 			release_sample_expr(expr);
 			return -1;
 		}
@@ -1061,7 +1061,7 @@ static int tcp_parse_tcp_rep(char **args, int section_type, struct proxy *curpx,
 
 	rule = calloc(1, sizeof(*rule));
 	if (!rule) {
-		memprintf(err, "parsing [%s:%d] : out of memory", file, line);
+		memprintf(err, "parsing [%s:%d] : OOM", file, line);
 		return -1;
 	}
 	LIST_INIT(&rule->list);
@@ -1179,7 +1179,7 @@ static int tcp_parse_tcp_req(char **args, int section_type, struct proxy *curpx,
 
 	rule = calloc(1, sizeof(*rule));
 	if (!rule) {
-		memprintf(err, "parsing [%s:%d] : out of memory", file, line);
+		memprintf(err, "parsing [%s:%d] : OOM", file, line);
 		return -1;
 	}
 	LIST_INIT(&rule->list);

--- a/src/tcpcheck.c
+++ b/src/tcpcheck.c
@@ -2338,7 +2338,7 @@ struct tcpcheck_rule *parse_tcpcheck_action(char **args, int cur_arg, struct pro
 
 	actrule = calloc(1, sizeof(*actrule));
 	if (!actrule) {
-		memprintf(errmsg, "out of memory");
+		memprintf(errmsg, "OOM");
 		goto error;
 	}
 	actrule->kw = kw;
@@ -2352,7 +2352,7 @@ struct tcpcheck_rule *parse_tcpcheck_action(char **args, int cur_arg, struct pro
 
 	chk = calloc(1, sizeof(*chk));
 	if (!chk) {
-		memprintf(errmsg, "out of memory");
+		memprintf(errmsg, "OOM");
 		goto error;
 	}
 	chk->action = TCPCHK_ACT_ACTION_KW;
@@ -2484,7 +2484,7 @@ struct tcpcheck_rule *parse_tcpcheck_connect(char **args, int cur_arg, struct pr
 			free(comment);
 			comment = strdup(args[cur_arg]);
 			if (!comment) {
-				memprintf(errmsg, "out of memory");
+				memprintf(errmsg, "OOM");
 				goto error;
 			}
 		}
@@ -2508,7 +2508,7 @@ struct tcpcheck_rule *parse_tcpcheck_connect(char **args, int cur_arg, struct pr
 			free(sni);
 			sni = strdup(args[cur_arg]);
 			if (!sni) {
-				memprintf(errmsg, "out of memory");
+				memprintf(errmsg, "OOM");
 				goto error;
 			}
 		}
@@ -2541,7 +2541,7 @@ struct tcpcheck_rule *parse_tcpcheck_connect(char **args, int cur_arg, struct pr
 
 	chk = calloc(1, sizeof(*chk));
 	if (!chk) {
-		memprintf(errmsg, "out of memory");
+		memprintf(errmsg, "OOM");
 		goto error;
 	}
 	chk->action  = TCPCHK_ACT_CONNECT;
@@ -2601,7 +2601,7 @@ struct tcpcheck_rule *parse_tcpcheck_send(char **args, int cur_arg, struct proxy
 			free(comment);
 			comment = strdup(args[cur_arg]);
 			if (!comment) {
-				memprintf(errmsg, "out of memory");
+				memprintf(errmsg, "OOM");
 				goto error;
 			}
 		}
@@ -2615,7 +2615,7 @@ struct tcpcheck_rule *parse_tcpcheck_send(char **args, int cur_arg, struct proxy
 
 	chk = calloc(1, sizeof(*chk));
 	if (!chk) {
-		memprintf(errmsg, "out of memory");
+		memprintf(errmsg, "OOM");
 		goto error;
 	}
 	chk->action      = TCPCHK_ACT_SEND;
@@ -2626,7 +2626,7 @@ struct tcpcheck_rule *parse_tcpcheck_send(char **args, int cur_arg, struct proxy
 	case TCPCHK_SEND_STRING:
 		chk->send.data = ist(strdup(data));
 		if (!isttest(chk->send.data)) {
-			memprintf(errmsg, "out of memory");
+			memprintf(errmsg, "OOM");
 			goto error;
 		}
 		break;
@@ -2746,7 +2746,7 @@ struct tcpcheck_rule *parse_tcpcheck_send_http(char **args, int cur_arg, struct 
 			free(comment);
 			comment = strdup(args[cur_arg]);
 			if (!comment) {
-				memprintf(errmsg, "out of memory");
+				memprintf(errmsg, "OOM");
 				goto error;
 			}
 		}
@@ -2762,7 +2762,7 @@ struct tcpcheck_rule *parse_tcpcheck_send_http(char **args, int cur_arg, struct 
 
 	chk = calloc(1, sizeof(*chk));
 	if (!chk) {
-		memprintf(errmsg, "out of memory");
+		memprintf(errmsg, "OOM");
 		goto error;
 	}
 	chk->action    = TCPCHK_ACT_SEND;
@@ -2776,7 +2776,7 @@ struct tcpcheck_rule *parse_tcpcheck_send_http(char **args, int cur_arg, struct 
 		chk->send.http.meth.str.area = strdup(meth);
 		chk->send.http.meth.str.data = strlen(meth);
 		if (!chk->send.http.meth.str.area) {
-			memprintf(errmsg, "out of memory");
+			memprintf(errmsg, "OOM");
 			goto error;
 		}
 	}
@@ -2792,7 +2792,7 @@ struct tcpcheck_rule *parse_tcpcheck_send_http(char **args, int cur_arg, struct 
 		else {
 			chk->send.http.uri = ist(strdup(uri));
 			if (!isttest(chk->send.http.uri)) {
-				memprintf(errmsg, "out of memory");
+				memprintf(errmsg, "OOM");
 				goto error;
 			}
 		}
@@ -2800,20 +2800,20 @@ struct tcpcheck_rule *parse_tcpcheck_send_http(char **args, int cur_arg, struct 
 	if (vsn) {
 		chk->send.http.vsn = ist(strdup(vsn));
 		if (!isttest(chk->send.http.vsn)) {
-			memprintf(errmsg, "out of memory");
+			memprintf(errmsg, "OOM");
 			goto error;
 		}
 	}
 	for (i = 0; istlen(hdrs[i].n); i++) {
 		hdr = calloc(1, sizeof(*hdr));
 		if (!hdr) {
-			memprintf(errmsg, "out of memory");
+			memprintf(errmsg, "OOM");
 			goto error;
 		}
 		LIST_INIT(&hdr->value);
 		hdr->name = istdup(hdrs[i].n);
 		if (!isttest(hdr->name)) {
-			memprintf(errmsg, "out of memory");
+			memprintf(errmsg, "OOM");
 			goto error;
 		}
 
@@ -2836,7 +2836,7 @@ struct tcpcheck_rule *parse_tcpcheck_send_http(char **args, int cur_arg, struct 
 		else {
 			chk->send.http.body = ist(strdup(body));
 			if (!isttest(chk->send.http.body)) {
-				memprintf(errmsg, "out of memory");
+				memprintf(errmsg, "OOM");
 				goto error;
 			}
 		}
@@ -2865,13 +2865,13 @@ struct tcpcheck_rule *parse_tcpcheck_comment(char **args, int cur_arg, struct pr
 	cur_arg++;
 	comment = strdup(args[cur_arg]);
 	if (!comment) {
-		memprintf(errmsg, "out of memory");
+		memprintf(errmsg, "OOM");
 		goto error;
 	}
 
 	chk = calloc(1, sizeof(*chk));
 	if (!chk) {
-		memprintf(errmsg, "out of memory");
+		memprintf(errmsg, "OOM");
 		goto error;
 	}
 	chk->action  = TCPCHK_ACT_COMMENT;
@@ -3140,7 +3140,7 @@ struct tcpcheck_rule *parse_tcpcheck_expect(char **args, int cur_arg, struct pro
 			free(comment);
 			comment = strdup(args[cur_arg]);
 			if (!comment) {
-				memprintf(errmsg, "out of memory");
+				memprintf(errmsg, "OOM");
 				goto error;
 			}
 		}
@@ -3289,7 +3289,7 @@ struct tcpcheck_rule *parse_tcpcheck_expect(char **args, int cur_arg, struct pro
 
 	chk = calloc(1, sizeof(*chk));
 	if (!chk) {
-		memprintf(errmsg, "out of memory");
+		memprintf(errmsg, "OOM");
 		goto error;
 	}
 	chk->action  = TCPCHK_ACT_EXPECT;
@@ -3341,7 +3341,7 @@ struct tcpcheck_rule *parse_tcpcheck_expect(char **args, int cur_arg, struct pro
 			chk->expect.codes.codes = my_realloc2(chk->expect.codes.codes,
 							      chk->expect.codes.num * sizeof(*chk->expect.codes.codes));
 			if (!chk->expect.codes.codes) {
-				memprintf(errmsg, "out of memory");
+				memprintf(errmsg, "OOM");
 				goto error;
 			}
 			chk->expect.codes.codes[chk->expect.codes.num-1][0] = c1;
@@ -3361,7 +3361,7 @@ struct tcpcheck_rule *parse_tcpcheck_expect(char **args, int cur_arg, struct pro
 	case TCPCHK_EXPECT_HTTP_BODY:
 		chk->expect.data = ist(strdup(pattern));
 		if (!isttest(chk->expect.data)) {
-			memprintf(errmsg, "out of memory");
+			memprintf(errmsg, "OOM");
 			goto error;
 		}
 		break;
@@ -3416,7 +3416,7 @@ struct tcpcheck_rule *parse_tcpcheck_expect(char **args, int cur_arg, struct pro
 		else {
 			chk->expect.hdr.name = ist(strdup(npat));
 			if (!isttest(chk->expect.hdr.name)) {
-				memprintf(errmsg, "out of memory");
+				memprintf(errmsg, "OOM");
 				goto error;
 			}
 		}
@@ -3446,7 +3446,7 @@ struct tcpcheck_rule *parse_tcpcheck_expect(char **args, int cur_arg, struct pro
 		else {
 			chk->expect.hdr.value = ist(strdup(vpat));
 			if (!isttest(chk->expect.hdr.value)) {
-				memprintf(errmsg, "out of memory");
+				memprintf(errmsg, "OOM");
 				goto error;
 			}
 		}
@@ -3717,7 +3717,7 @@ static int check_proxy_tcpcheck(struct proxy *px)
 		chk = calloc(1, sizeof(*chk));
 		if (!chk) {
 			ha_alert("proxy '%s': unable to add implicit tcp-check connect rule "
-				 "(out of memory).\n", px->id);
+				 "(OOM).\n", px->id);
 			ret |= ERR_ALERT | ERR_FATAL;
 			goto out;
 		}
@@ -3882,7 +3882,7 @@ static int proxy_parse_tcpcheck(char **args, int section, struct proxy *curpx,
 	if (rs == NULL) {
 		rs = create_tcpcheck_ruleset(b_orig(&trash));
 		if (rs == NULL) {
-			memprintf(errmsg, "out of memory.\n");
+			memprintf(errmsg, "OOM.\n");
 			goto error;
 		}
 	}
@@ -3983,7 +3983,7 @@ static int proxy_parse_httpcheck(char **args, int section, struct proxy *curpx,
 	if (rs == NULL) {
 		rs = create_tcpcheck_ruleset(b_orig(&trash));
 		if (rs == NULL) {
-			memprintf(errmsg, "out of memory.\n");
+			memprintf(errmsg, "OOM.\n");
 			goto error;
 		}
 	}
@@ -4083,7 +4083,7 @@ int proxy_parse_redis_check_opt(char **args, int cur_arg, struct proxy *curpx, c
 
 	rs = create_tcpcheck_ruleset("*redis-check");
 	if (rs == NULL) {
-		ha_alert("parsing [%s:%d] : out of memory.\n", file, line);
+		ha_alert("parsing [%s:%d] : OOM.\n", file, line);
 		goto error;
 	}
 
@@ -4184,7 +4184,7 @@ int proxy_parse_ssl_hello_chk_opt(char **args, int cur_arg, struct proxy *curpx,
 
 	rs = create_tcpcheck_ruleset("*ssl-hello-check");
 	if (rs == NULL) {
-		ha_alert("parsing [%s:%d] : out of memory.\n", file, line);
+		ha_alert("parsing [%s:%d] : OOM.\n", file, line);
 		goto error;
 	}
 
@@ -4266,7 +4266,7 @@ int proxy_parse_smtpchk_opt(char **args, int cur_arg, struct proxy *curpx, const
 
 	var = create_tcpcheck_var(ist("check.smtp_cmd"));
 	if (cmd == NULL || var == NULL) {
-		ha_alert("parsing [%s:%d] : out of memory.\n", file, line);
+		ha_alert("parsing [%s:%d] : OOM.\n", file, line);
 		goto error;
 	}
 	var->data.type = SMP_T_STR;
@@ -4283,7 +4283,7 @@ int proxy_parse_smtpchk_opt(char **args, int cur_arg, struct proxy *curpx, const
 
 	rs = create_tcpcheck_ruleset("*smtp-check");
 	if (rs == NULL) {
-		ha_alert("parsing [%s:%d] : out of memory.\n", file, line);
+		ha_alert("parsing [%s:%d] : OOM.\n", file, line);
 		goto error;
 	}
 
@@ -4410,7 +4410,7 @@ int proxy_parse_pgsql_check_opt(char **args, int cur_arg, struct proxy *curpx, c
 
 		var = create_tcpcheck_var(ist("check.username"));
 		if (user == NULL || var == NULL) {
-			ha_alert("parsing [%s:%d] : out of memory.\n", file, line);
+			ha_alert("parsing [%s:%d] : OOM.\n", file, line);
 			goto error;
 		}
 		var->data.type = SMP_T_STR;
@@ -4423,7 +4423,7 @@ int proxy_parse_pgsql_check_opt(char **args, int cur_arg, struct proxy *curpx, c
 
 		var = create_tcpcheck_var(ist("check.plen"));
 		if (var == NULL) {
-			ha_alert("parsing [%s:%d] : out of memory.\n", file, line);
+			ha_alert("parsing [%s:%d] : OOM.\n", file, line);
 			goto error;
 		}
 		var->data.type = SMP_T_SINT;
@@ -4444,7 +4444,7 @@ int proxy_parse_pgsql_check_opt(char **args, int cur_arg, struct proxy *curpx, c
 
 	rs = create_tcpcheck_ruleset("*pgsql-check");
 	if (rs == NULL) {
-		ha_alert("parsing [%s:%d] : out of memory.\n", file, line);
+		ha_alert("parsing [%s:%d] : OOM.\n", file, line);
 		goto error;
 	}
 
@@ -4613,7 +4613,7 @@ int proxy_parse_mysql_check_opt(char **args, int cur_arg, struct proxy *curpx, c
 		userlen = strlen(args[cur_arg+1]);
 
 		if (hdr == NULL || user == NULL) {
-			ha_alert("parsing [%s:%d] : out of memory.\n", file, line);
+			ha_alert("parsing [%s:%d] : OOM.\n", file, line);
 			goto error;
 		}
 
@@ -4640,7 +4640,7 @@ int proxy_parse_mysql_check_opt(char **args, int cur_arg, struct proxy *curpx, c
 
 		var = create_tcpcheck_var(ist("check.header"));
 		if (var == NULL) {
-			ha_alert("parsing [%s:%d] : out of memory.\n", file, line);
+			ha_alert("parsing [%s:%d] : OOM.\n", file, line);
 			goto error;
 		}
 		var->data.type = SMP_T_STR;
@@ -4653,7 +4653,7 @@ int proxy_parse_mysql_check_opt(char **args, int cur_arg, struct proxy *curpx, c
 
 		var = create_tcpcheck_var(ist("check.username"));
 		if (var == NULL) {
-			ha_alert("parsing [%s:%d] : out of memory.\n", file, line);
+			ha_alert("parsing [%s:%d] : OOM.\n", file, line);
 			goto error;
 		}
 		var->data.type = SMP_T_STR;
@@ -4671,7 +4671,7 @@ int proxy_parse_mysql_check_opt(char **args, int cur_arg, struct proxy *curpx, c
 
 	rs = create_tcpcheck_ruleset(mysql_rsname);
 	if (rs == NULL) {
-		ha_alert("parsing [%s:%d] : out of memory.\n", file, line);
+		ha_alert("parsing [%s:%d] : OOM.\n", file, line);
 		goto error;
 	}
 
@@ -4766,7 +4766,7 @@ int proxy_parse_ldap_check_opt(char **args, int cur_arg, struct proxy *curpx, co
 
 	rs = create_tcpcheck_ruleset("*ldap-check");
 	if (rs == NULL) {
-		ha_alert("parsing [%s:%d] : out of memory.\n", file, line);
+		ha_alert("parsing [%s:%d] : OOM.\n", file, line);
 		goto error;
 	}
 
@@ -4846,12 +4846,12 @@ int proxy_parse_spop_check_opt(char **args, int cur_arg, struct proxy *curpx, co
 
 	rs = create_tcpcheck_ruleset("*spop-check");
 	if (rs == NULL) {
-		ha_alert("parsing [%s:%d] : out of memory.\n", file, line);
+		ha_alert("parsing [%s:%d] : OOM.\n", file, line);
 		goto error;
 	}
 
 	if (spoe_prepare_healthcheck_request(&spop_req, &spop_len) == -1) {
-		ha_alert("parsing [%s:%d] : out of memory.\n", file, line);
+		ha_alert("parsing [%s:%d] : OOM.\n", file, line);
 		goto error;
 	}
 	chunk_reset(&trash);
@@ -4920,7 +4920,7 @@ static struct tcpcheck_rule *proxy_parse_httpchk_req(char **args, int cur_arg, s
 
 	chk = calloc(1, sizeof(*chk));
 	if (!chk) {
-		memprintf(errmsg, "out of memory");
+		memprintf(errmsg, "OOM");
 		goto error;
 	}
 	chk->action    = TCPCHK_ACT_SEND;
@@ -4946,21 +4946,21 @@ static struct tcpcheck_rule *proxy_parse_httpchk_req(char **args, int cur_arg, s
 		chk->send.http.meth.str.area = strdup(meth);
 		chk->send.http.meth.str.data = strlen(meth);
 		if (!chk->send.http.meth.str.area) {
-			memprintf(errmsg, "out of memory");
+			memprintf(errmsg, "OOM");
 			goto error;
 		}
 	}
 	if (uri) {
 		chk->send.http.uri = ist(strdup(uri));
 		if (!isttest(chk->send.http.uri)) {
-			memprintf(errmsg, "out of memory");
+			memprintf(errmsg, "OOM");
 			goto error;
 		}
 	}
 	if (vsn) {
 		chk->send.http.vsn = ist(strdup(vsn));
 		if (!isttest(chk->send.http.vsn)) {
-			memprintf(errmsg, "out of memory");
+			memprintf(errmsg, "OOM");
 			goto error;
 		}
 	}
@@ -4986,13 +4986,13 @@ static struct tcpcheck_rule *proxy_parse_httpchk_req(char **args, int cur_arg, s
 		for (i = 0; istlen(tmp_hdrs[i].n); i++) {
 			hdr = calloc(1, sizeof(*hdr));
 			if (!hdr) {
-				memprintf(errmsg, "out of memory");
+				memprintf(errmsg, "OOM");
 				goto error;
 			}
 			LIST_INIT(&hdr->value);
 			hdr->name = istdup(tmp_hdrs[i].n);
 			if (!hdr->name.ptr) {
-				memprintf(errmsg, "out of memory");
+				memprintf(errmsg, "OOM");
 				goto error;
 			}
 
@@ -5007,7 +5007,7 @@ static struct tcpcheck_rule *proxy_parse_httpchk_req(char **args, int cur_arg, s
 	if (body) {
 		chk->send.http.body = ist(strdup(body));
 		if (!isttest(chk->send.http.body)) {
-			memprintf(errmsg, "out of memory");
+			memprintf(errmsg, "OOM");
 			goto error;
 		}
 	}
@@ -5064,7 +5064,7 @@ int proxy_parse_httpchk_opt(char **args, int cur_arg, struct proxy *curpx, const
 	if (rs == NULL) {
 		rs = create_tcpcheck_ruleset(b_orig(&trash));
 		if (rs == NULL) {
-			ha_alert("parsing [%s:%d] : out of memory.\n", file, line);
+			ha_alert("parsing [%s:%d] : OOM.\n", file, line);
 			goto error;
 		}
 	}
@@ -5134,7 +5134,7 @@ int proxy_parse_tcp_check_opt(char **args, int cur_arg, struct proxy *curpx, con
 	if (rs == NULL) {
 		rs = create_tcpcheck_ruleset(b_orig(&trash));
 		if (rs == NULL) {
-			ha_alert("parsing [%s:%d] : out of memory.\n", file, line);
+			ha_alert("parsing [%s:%d] : OOM.\n", file, line);
 			goto error;
 		}
 	}

--- a/src/tools.c
+++ b/src/tools.c
@@ -954,7 +954,7 @@ struct sockaddr_storage *str2sa_range(const char *str, int *port, int *low, int 
 
 	str2 = back = env_expand(strdup(str));
 	if (str2 == NULL) {
-		memprintf(err, "out of memory in '%s'\n", __FUNCTION__);
+		memprintf(err, "OOM in '%s'\n", __FUNCTION__);
 		goto out;
 	}
 
@@ -2536,7 +2536,7 @@ int parse_binary(const char *source, char **binstr, int *binstrlen, char **err)
 	if (!*binstr) {
 		*binstr = calloc(len, sizeof(**binstr));
 		if (!*binstr) {
-			memprintf(err, "out of memory while loading string pattern");
+			memprintf(err, "OOM while loading string pattern");
 			return 0;
 		}
 		alloc = 1;
@@ -4473,13 +4473,13 @@ int list_append_word(struct list *li, const char *str, char **err)
 
 	wl = calloc(1, sizeof(*wl));
 	if (!wl) {
-		memprintf(err, "out of memory");
+		memprintf(err, "OOM");
 		goto fail_wl;
 	}
 
 	wl->s = strdup(str);
 	if (!wl->s) {
-		memprintf(err, "out of memory");
+		memprintf(err, "OOM");
 		goto fail_wl_s;
 	}
 

--- a/src/vars.c
+++ b/src/vars.c
@@ -965,7 +965,7 @@ static int vars_parse_global_set_var(char **args, int section_type, struct proxy
 
 	if (use_fmt && !(sess = session_new(&px, NULL, &objt))) {
 		release_sample_expr(rule.arg.vars.expr);
-		memprintf(err, "'%s': out of memory when trying to set variable '%s' in the global section.", args[0], args[1]);
+		memprintf(err, "'%s': OOM when trying to set variable '%s' in the global section.", args[0], args[1]);
 		goto end;
 	}
 


### PR DESCRIPTION
Refers to #1025 
Using  well known word 'OOM' instead of 'Out of Memory'
This will reduce binary size as well.
Have tried to keep context wherever required.