### PR TITLE
BUG/MEDIUM: lua: fix invalid return types in hlua_http_msg_get_body

### DIFF
--- a/src/hlua.c
+++ b/src/hlua.c
@@ -6343,6 +6343,10 @@ static int _hlua_http_msg_dup(struct http_msg *msg, lua_State *L, size_t offset,
 					lua_pop(L, 1);
 					lua_pushnil(L);
 				}
+				else
+				{
+					luaL_pushresult(&b);
+				}
 				goto end;
 		}
 		offset = 0;


### PR DESCRIPTION
hlua_http_msg_get_body must return either a Lua string or nil.
For some HTTPMessage objects, HTX_BLK_EOT blocks are also present in the HTX buffer along with HTX_BLK_DATA blocks. In such cases, _hlua_http_msg_dup will start copying data into a luaL_Buffer until it encounters an HTX_BLK_EOT. But then instead of pushing neither the luaL_Buffer nor `nil` to the Lua stack, the function will return immediately. The end result will be that the caller of the HTTPMessage.get_body() method from a Lua filter will see whatever object was on top of the stack as return value. It may be either a userdata object if HTTPMessage.get_body was called with only two arguments, or the third argument itself if called with three arguments. Hence HTTPMessage.get_body would return either nil, or HTTPMessage body as Lua string, or a userdata objects, or number.
This fix ensure that HTTPMessage.get_body() will always return either a string or nil.

Fixes #1426 .