### PR TITLE
fix problem which don't support 1-byte atomic instructions natively on RISCV64 architecture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -930,7 +930,7 @@ else
 endif
 
 haproxy: $(OPTIONS_OBJS) $(OBJS)
-	$(cmd_LD) $(LDFLAGS) -o $@ $^ $(LDOPTS)
+	$(cmd_LD) $(LDFLAGS) -o $@ $^ $(LDOPTS) -latomic 
 
 objsize: haproxy
 	$(Q)objdump -t $^|grep ' g '|grep -F '.text'|awk '{print $$5 FS $$6}'|sort
@@ -945,7 +945,7 @@ admin/dyncookie/dyncookie: admin/dyncookie/dyncookie.o
 	$(cmd_LD) $(LDFLAGS) -o $@ $^ $(LDOPTS)
 
 dev/flags/flags: dev/flags/flags.o
-	$(cmd_LD) $(LDFLAGS) -o $@ $^ $(LDOPTS)
+	$(cmd_LD) $(LDFLAGS) -o $@ $^ $(LDOPTS) -latomic 
 
 dev/hpack/%: dev/hpack/%.o
 	$(cmd_LD) $(LDFLAGS) -o $@ $^ $(LDOPTS)


### PR DESCRIPTION
When building on RISCV64 architecture, I met the following error.
```shell
/usr/bin/ld: src/cfgparse.o: in function `check_config_validity':
/home/haproxy/src/cfgparse.c:2476: undefined reference to `__atomic_exchange_1'
/usr/bin/ld: src/dns.o: in function `dns_resolve_send':
/home/haproxy/src/dns.c:313: undefined reference to `__atomic_fetch_sub_1'
/usr/bin/ld: /home/haproxy/src/dns.c:354: undefined reference to `__atomic_fetch_add_1'
/usr/bin/ld: /home/haproxy/src/dns.c:304: undefined reference to `__atomic_fetch_add_1'
/usr/bin/ld: src/dns.o: in function `dns_session_io_handler':
/home/haproxy/src/dns.c:726: undefined reference to `__atomic_fetch_sub_1'
/usr/bin/ld: /home/haproxy/src/dns.c:713: undefined reference to `__atomic_fetch_add_1'
/usr/bin/ld: src/dns.o: in function `b_getblk':
/home/haproxy/include/haproxy/buf.h:328: undefined reference to `__atomic_fetch_add_1'
/usr/bin/ld: src/dns.o: in function `pool_free':
/home/haproxy/include/haproxy/pool.h:291: undefined reference to `__atomic_fetch_add_1'
/usr/bin/ld: src/dns.o: in function `__pool_alloc':
/home/haproxy/include/haproxy/pool.h:246: undefined reference to `__atomic_fetch_sub_1'
/usr/bin/ld: src/dns.o: in function `pool_free':
/home/haproxy/include/haproxy/pool.h:291: undefined reference to `__atomic_fetch_add_1'
/usr/bin/ld: src/dns.o: in function `dns_process_req':
/home/haproxy/src/dns.c:1196: undefined reference to `__atomic_fetch_add_1'
/usr/bin/ld: src/sink.o: in function `sink_forward_oc_io_handler':
/home/haproxy/src/sink.c:515: undefined reference to `__atomic_fetch_sub_1'
/usr/bin/ld: /home/haproxy/src/sink.c:549: undefined reference to `__atomic_fetch_add_1'
/usr/bin/ld: /home/haproxy/src/sink.c:549: undefined reference to `__atomic_fetch_add_1'
/usr/bin/ld: /home/haproxy/src/sink.c:501: undefined reference to `__atomic_fetch_add_1'
/usr/bin/ld: src/sink.o: in function `sink_forward_io_handler':
/home/haproxy/src/sink.c:375: undefined reference to `__atomic_fetch_sub_1'
/usr/bin/ld: src/sink.o: in function `b_peek_ofs':
/home/haproxy/include/haproxy/buf.h:142: undefined reference to `__atomic_fetch_add_1'
/usr/bin/ld: /home/haproxy/include/haproxy/buf.h:143: undefined reference to `__atomic_fetch_add_1'
/usr/bin/ld: /home/haproxy/include/haproxy/buf.h:143: undefined reference to `__atomic_fetch_add_1'
/usr/bin/ld: src/ring.o: in function `ring_detach_appctx':
/home/haproxy/src/ring.c:240: undefined reference to `__atomic_fetch_sub_1'
/usr/bin/ld: src/ring.o: in function `cli_io_handler_show_ring':
/home/haproxy/src/ring.c:320: undefined reference to `__atomic_fetch_sub_1'
/usr/bin/ld: /home/haproxy/src/ring.c:354: undefined reference to `__atomic_fetch_add_1'
/usr/bin/ld: /home/haproxy/src/ring.c:354: undefined reference to `__atomic_fetch_add_1'
/usr/bin/ld: /home/haproxy/src/ring.c:311: undefined reference to `__atomic_fetch_add_1'
collect2: error: ld returned 1 exit status
make: *** [Makefile:933: haproxy] Error 1
```
It seems the target platform doesn't support 1-byte atomic instructions natively. So I add `-latomic` to support when compiling.
The result: 
```shell
[root@master0 haproxy]# ./haproxy
HAProxy version 2.5-dev13-47940c-45 2021/11/10 - https://haproxy.org/
Status: development branch - not safe for use in production.
Known bugs: https://github.com/haproxy/haproxy/issues?q=is:issue+is:open
Running on: Linux 5.4.61 #20 SMP Thu Aug 26 11:50:01 CST 2021 riscv64
Usage : haproxy [-f <cfgfile|cfgdir>]* [ -vdVD ] [ -n <maxconn> ] [ -N <maxpconn> ]
        [ -p <pidfile> ] [ -m <max megs> ] [ -C <dir> ] [-- <cfgfile>*]
        -v displays version ; -vv shows known build options.
        -d enters debug mode ; -db only disables background mode.
        -dM[<byte>] poisons memory with <byte> (defaults to 0x50)
        -V enters verbose mode (disables quiet mode)
        -D goes daemon ; -C changes to <dir> before loading files.
        -W master-worker mode.
        -q quiet mode : don't display messages
        -c check mode : only check config files and exit
        -cc check condition : evaluate a condition and exit
        -n sets the maximum total # of connections (uses ulimit -n)
        -m limits the usable amount of memory (in MB)
        -N sets the default, per-proxy maximum # of connections (0)
        -L set local peer name (default to hostname)
        -p writes pids of all children to this file
        -de disables epoll() usage even when available
        -dp disables poll() usage even when available
        -dS disables splice usage (broken on old kernels)
        -dG disables getaddrinfo() usage
        -dR disables SO_REUSEPORT usage
        -dr ignores server address resolution failures
        -dV disables SSL verify on servers side
        -dW fails if any warning is emitted
        -dD diagnostic mode : warn about suspicious configuration statements
        -sf/-st [pid ]* finishes/terminates old pids.
        -x <unix_socket> get listening sockets from a unix socket
        -S <bind>[,<bind options>...] new master CLI
```
My Platform:
```shell
[root@master0 haproxy]# uname -a
Linux master0 5.4.61 #20 SMP Thu Aug 26 11:50:01 CST 2021 riscv64 riscv64 riscv64 GNU/Linux
```
GCC version:
```shell
gcc (GCC) 9.3.1
Copyright (C) 2019 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```