### PR TITLE
fix: Correct data types list

### DIFF
--- a/doc/peers-v2.0.txt
+++ b/doc/peers-v2.0.txt
@@ -217,7 +217,7 @@ bit
  12: errors rate
  13: bytes in counter
  14: bytes in rate
- 15: bytes out rate
+ 15: bytes out counter
  16: bytes out rate
  17: gpc1
  18: gpc1 rate


### PR DESCRIPTION
There is a Typo in the peers-v2.0 Doc