### PR TITLE
Allow "no option forwardfor"

### DIFF
--- a/src/http_ana.c
+++ b/src/http_ana.c
@@ -673,7 +673,7 @@ int http_process_request(struct stream *s, struct channel *req, int an_bit)
 	 * 9: add X-Forwarded-For if either the frontend or the backend
 	 * asks for it.
 	 */
-	if ((sess->fe->options | s->be->options) & PR_O_FWDFOR) {
+	if ((sess->fe->options & s->be->options) & PR_O_FWDFOR) {
 		const struct sockaddr_storage *src = sc_src(s->scf);
 		struct http_hdr_ctx ctx = { .blk = NULL };
 		struct ist hdr = isttest(s->be->fwdfor_hdr_name) ? s->be->fwdfor_hdr_name : sess->fe->fwdfor_hdr_name;


### PR DESCRIPTION
Fixes #130 

* Move the `forwardfor` logic before we check the negation of options ( https://github.com/haproxy/haproxy/blob/94f763b5e4b2aafd2c6d65f074fdc28735556f25/src/cfgparse-listen.c#L2071 ) so we can negate it.
* Add logic to differentiate KWM_NO and KWM_STD so we modify options for the proxy.
* Modify logic to include the header only if both frontend and backend have the header enabled.

About this  last point (and the 2nd commit of this PR) , I'm not sure it's what I'm supposed to do.
Maybe I should also some `no_options` logic to properly disable the header in the backend ?

Also, this PR so far is missing docs, but I want the logic to be clear before writing the document (or should it be done the other way around ?).
Finally, it may also miss some tests, should I add them to https://github.com/haproxy/haproxy/blob/025945f12cde56dde22baec286393fd1f048c0fc/reg-tests/http-rules/except-forwardfor-originalto.vtc ?