### PR TITLE
DOC: fix function formatting for http-request set-var and set-var-fmt

### DIFF
--- a/doc/configuration.txt
+++ b/doc/configuration.txt
@@ -5773,8 +5773,8 @@ http-after-response set-status <status> [reason <str>]
   between 100 and 999. Please refer to "http-response set-status" for a complete
   description.
 
-http-after-response set-var(<var-name>[,<cond> ...]) <expr> [ { if | unless } <condition> ]
-http-after-response set-var-fmt(<var-name>[,<cond> ...]) <fmt> [ { if | unless } <condition> ]
+http-after-response set-var(<var-name>[,<cond>]) <expr> [ { if | unless } <condition> ]
+http-after-response set-var-fmt(<var-name>[,<cond>]) <fmt> [ { if | unless } <condition> ]
 
   This is used to set the contents of a variable. The variable is declared
   inline. Please refer to "http-request set-var" and "http-request set-var-fmt"


### PR DESCRIPTION
Hi. There is a formatting issue with `http-request set-var` and `http-request set-var-fmt`. When `dconv` builds the documentation it doesn't expect `...` in that part of the keyword so it gets skipped. 

![set-var](https://user-images.githubusercontent.com/10053187/194045009-b0ecab6a-8595-4fa5-b77d-816dfd112e30.png)

I don't feel comfortable editing `dconv` since it relies on a complex regex that might affect other keywords so I added a quick fix by removing `...`. 

<img width="415" alt="set-var-fix" src="https://user-images.githubusercontent.com/10053187/194045023-050ebf13-fb7e-4692-b520-526c06cc38bf.png">

_(The formatting on the screenshot above is a bit off because I did a local build and didn't serve the files from a webserver)_