### PR TITLE
BUG/MINOR: http-fetch: recognize IPv6 addresses in square brackets in req.hdr_ip()

### DIFF
--- a/reg-tests/http-rules/converters_ipmask_concat_strcmp_field_word.vtc
+++ b/reg-tests/http-rules/converters_ipmask_concat_strcmp_field_word.vtc
@@ -187,7 +187,7 @@ haproxy h2 -conf {
 # ipmask tests
 client c1 -connect ${h1_fe1_sock} -proxy2 "192.168.1.101:1234 127.0.0.1:2345" {
     txreq -hdr "Addr1: 2001:db8::1" \
-        -hdr "Addr2: 2001:db8::bad:c0f:ffff" \
+        -hdr "Addr2: [2001:db8::bad:c0f:ffff]" \
         -hdr "Addr3: 2001:db8:c001:c01a:ffff:ffff:10:ffff" \
         -hdr "Addr4: ::FFFF:192.168.1.101" \
         -hdr "Addr5: 192.168.1.2" \

--- a/src/http_fetch.c
+++ b/src/http_fetch.c
@@ -1024,7 +1024,15 @@ static int smp_fetch_hdr_ip(const struct arg *args, struct sample *smp, const ch
 				/* IPv4 address suffixed with ':' followed by a valid port number */
 				smp->data.type = SMP_T_IPV4;
 				break;
+			} else if (temp->area[0] == '[' && temp->area[smp->data.u.str.data-1] == ']') {
+				/* IPv6 address enclosed in square brackets */
+				temp->area[smp->data.u.str.data-1] = '\0';
+				if (inet_pton(AF_INET6, temp->area+1, &smp->data.u.ipv6)) {
+					smp->data.type = SMP_T_IPV6;
+					break;
+				}
 			} else if (inet_pton(AF_INET6, temp->area, &smp->data.u.ipv6)) {
+				/* plain IPv6 address */
 				smp->data.type = SMP_T_IPV6;
 				break;
 			}


### PR DESCRIPTION
Fixes haproxy/haproxy#2054

To comply with [RFC7239](https://www.rfc-editor.org/rfc/rfc7239.html#section-6.1) and [RFC3986](https://www.rfc-editor.org/rfc/rfc3986.html#section-3.2.2), the `req.hdr_ip()` should recognize IPv6 addresses in square brackets.

As the `inet_pton()` call does not support this format, the `smp_fetch_hdr_ip()` function was changed to trim possible `'['` and `']'` before calling `inet_pton()`.

Reg tests were updated to cover this case.