### PR TITLE
BUG/MINOR: http-fetch: recognize IPv6 addresses in square brackets in req.hdr_ip()

### DIFF
--- a/reg-tests/http-rules/converters_ipmask_concat_strcmp_field_word.vtc
+++ b/reg-tests/http-rules/converters_ipmask_concat_strcmp_field_word.vtc
@@ -1,7 +1,7 @@
 varnishtest "Minimal tests for 1.9 converters: ipmask,concat,strcmp,field,word"
 feature ignore_unknown_macro
 
-# ipmask tests server
+# ipmask,hdr_ip tests server
 server s1 {
    rxreq
    expect req.method == "GET"
@@ -28,6 +28,12 @@ server s1 {
    expect req.http.test5mask24 == "192.168.1.0"
    expect req.http.test6mask24 == "192.168.1.0"
    expect req.http.test6mask25 == "192.168.1.128"
+
+   expect req.http.ipv4plain    == "192.168.2.1"
+   expect req.http.ipv4port     == "192.168.2.1"
+   expect req.http.ipv6plain    == "2001:db8:c001:c01a:ffff:ffff:20:ffff"
+   expect req.http.ipv6brackets == "2001:db8:c001:c01a:ffff:ffff:20:ffff"
+
    txresp
 } -start
 
@@ -65,7 +71,7 @@ server s2 {
 } -start
 
 
-# ipmask tests with accept-proxy bind
+# ipmask,hdr_ip tests with accept-proxy bind
 haproxy h1 -conf {
   defaults
     mode http
@@ -112,6 +118,12 @@ haproxy h1 -conf {
     http-request track-sc0 src,ipmask(24) table be1
     http-request track-sc1 hdr_ip(Addr4),ipmask(32) table be1
     http-request track-sc2 hdr_ip(Addr3),ipmask(24,64) table be1
+
+    # hdr_ip tests
+    http-request set-header IPv4plain    %[req.hdr_ip(AddrIPv4plain)]
+    http-request set-header IPv4port     %[req.hdr_ip(AddrIPv4port)]
+    http-request set-header IPv6plain    %[req.hdr_ip(AddrIPv6plain)]
+    http-request set-header IPv6brackets %[req.hdr_ip(AddrIPv6brackets)]
 
     default_backend be1
 
@@ -184,14 +196,18 @@ haproxy h2 -conf {
     server s2 ${s2_addr}:${s2_port}
 } -start
 
-# ipmask tests
+# ipmask,hdr_ip tests
 client c1 -connect ${h1_fe1_sock} -proxy2 "192.168.1.101:1234 127.0.0.1:2345" {
     txreq -hdr "Addr1: 2001:db8::1" \
         -hdr "Addr2: 2001:db8::bad:c0f:ffff" \
         -hdr "Addr3: 2001:db8:c001:c01a:ffff:ffff:10:ffff" \
         -hdr "Addr4: ::FFFF:192.168.1.101" \
         -hdr "Addr5: 192.168.1.2" \
-        -hdr "Addr6: 192.168.1.255"
+        -hdr "Addr6: 192.168.1.255" \
+        -hdr "AddrIPv4plain: 192.168.2.1" \
+        -hdr "AddrIPv4port: 192.168.2.1:6789" \
+        -hdr "AddrIPv6plain: 2001:db8:c001:c01a:ffff:ffff:20:ffff" \
+        -hdr "AddrIPv6brackets: [2001:db8:c001:c01a:ffff:ffff:20:ffff]"
     rxresp
     expect resp.status == 200
 } -run

--- a/src/http_fetch.c
+++ b/src/http_fetch.c
@@ -1024,7 +1024,15 @@ static int smp_fetch_hdr_ip(const struct arg *args, struct sample *smp, const ch
 				/* IPv4 address suffixed with ':' followed by a valid port number */
 				smp->data.type = SMP_T_IPV4;
 				break;
+			} else if (temp->area[0] == '[' && temp->area[smp->data.u.str.data-1] == ']') {
+				/* IPv6 address enclosed in square brackets */
+				temp->area[smp->data.u.str.data-1] = '\0';
+				if (inet_pton(AF_INET6, temp->area+1, &smp->data.u.ipv6)) {
+					smp->data.type = SMP_T_IPV6;
+					break;
+				}
 			} else if (inet_pton(AF_INET6, temp->area, &smp->data.u.ipv6)) {
+				/* plain IPv6 address */
 				smp->data.type = SMP_T_IPV6;
 				break;
 			}


### PR DESCRIPTION
Fixes haproxy/haproxy#2054

To comply with [RFC7239](https://www.rfc-editor.org/rfc/rfc7239.html#section-6.1) and [RFC3986](https://www.rfc-editor.org/rfc/rfc3986.html#section-3.2.2), the `req.hdr_ip()` should recognize IPv6 addresses in square brackets.

As the `inet_pton()` call does not support this format, the `smp_fetch_hdr_ip()` function was changed to trim possible `'['` and `']'` before calling `inet_pton()`.

New reg test cases were added to cover all 4 branches of smp_fetch_hdr_ip().