### PR TITLE
Allow load of non-existing pattern files.

### DIFF
--- a/doc/configuration.txt
+++ b/doc/configuration.txt
@@ -1196,6 +1196,7 @@ The following keywords are supported in the "global" section :
    - tune.maxpollevents
    - tune.maxrewrite
    - tune.memory.hot-size
+   - tune.pattern.allow-non-existing-file
    - tune.pattern.cache-size
    - tune.peers.max-updates-at-once
    - tune.pipesize
@@ -3304,6 +3305,14 @@ tune.memory.hot-size <number>
   change this value, or to proceed in small increments. In order to completely
   disable the per-thread CPU caches, using a very small value could work, but
   it is better to use "-dMno-cache" on the command-line.
+
+tune.pattern.allow-non-existing-file
+  Enables the loading of non-existent pattern files used in maps/ACLs. This can
+  be useful in cases where the maps are managed through the runtime API and/or 
+  LUA and there's no need for this file to exists in the local filesystem.
+
+  Important to note is that any changes to the map does not create the file or
+  write any information back to the filesystem, just like with existing patterns.
 
 tune.pattern.cache-size <number>
   Sets the size of the pattern lookup cache to <number> entries. This is an LRU

--- a/include/haproxy/global-t.h
+++ b/include/haproxy/global-t.h
@@ -169,6 +169,7 @@ struct global {
 		unsigned short idle_timer; /* how long before an empty buffer is considered idle (ms) */
 		int nb_stk_ctr;       /* number of stick counters, defaults to MAX_SESS_STKCTR */
 		int default_shards; /* default shards for listeners, or -1 (by-thread) or -2 (by-group) */
+		int allow_non_existent_pattern_file; /* allow non existent pattern files to be loaded. */
 #ifdef USE_QUIC
 		unsigned int quic_backend_max_idle_timeout;
 		unsigned int quic_frontend_max_idle_timeout;

--- a/src/cfgparse-global.c
+++ b/src/cfgparse-global.c
@@ -38,7 +38,7 @@ static const char *common_kw_list[] = {
 	"tune.sndbuf.client", "tune.sndbuf.server", "tune.pipesize",
 	"tune.http.cookielen", "tune.http.logurilen", "tune.http.maxhdr",
 	"tune.comp.maxlevel", "tune.pattern.cache-size",
-	"tune.fast-forward", "uid", "gid",
+	"tune.pattern.allow-non-existing-file", "tune.fast-forward", "uid", "gid",
 	"external-check", "user", "group", "nbproc", "maxconn",
 	"ssl-server-verify", "maxconnrate", "maxsessrate", "maxsslrate",
 	"maxcomprate", "maxpipes", "maxzlibmem", "maxcompcpuusage", "ulimit-n",
@@ -493,6 +493,10 @@ int cfg_parse_global(const char *file, int linenum, char **args, int kwm)
 			err_code |= ERR_ALERT | ERR_FATAL;
 			goto out;
 		}
+	}
+	else if (strcmp(args[0], "tune.pattern.allow-non-existing-file") == 0) {
+		ha_notice("Non-existing pattern files are allowed to be loaded (this affects Maps/ACLs).\n");
+		global.tune.allow_non_existent_pattern_file = 1;
 	}
 	else if (strcmp(args[0], "tune.disable-fast-forward") == 0) {
 		if (!experimental_directives_allowed) {

--- a/src/haproxy.c
+++ b/src/haproxy.c
@@ -192,6 +192,7 @@ struct global global = {
 		.maxrewrite = MAXREWRITE,
 		.reserved_bufs = RESERVED_BUFS,
 		.pattern_cache = DEFAULT_PAT_LRU_SIZE,
+		.allow_non_existent_pattern_file = 0,
 		.pool_low_ratio  = 20,
 		.pool_high_ratio = 25,
 		.max_http_hdr = MAX_HTTP_HDR,

--- a/src/pattern.c
+++ b/src/pattern.c
@@ -2238,8 +2238,14 @@ int pat_ref_read_from_file_smp(struct pat_ref *ref, const char *filename, char *
 
 	file = fopen(filename, "r");
 	if (!file) {
-		memprintf(err, "failed to open pattern file <%s>", filename);
-		return 0;
+		/* Allow the loading of a non existing file */
+		if (global.tune.allow_non_existent_pattern_file) {
+			ha_notice("Pattern file <%s> was not found but loaded because 'tune.pattern.allow-non-existing-file' is enabled.\n", filename);
+			return 1;
+		}else {
+			memprintf(err, "failed to open pattern file <%s>", filename);
+			return 0;
+		}
 	}
 
 	/* now parse all patterns. The file may contain only one pattern
@@ -2320,8 +2326,14 @@ int pat_ref_read_from_file(struct pat_ref *ref, const char *filename, char **err
 
 	file = fopen(filename, "r");
 	if (!file) {
-		memprintf(err, "failed to open pattern file <%s>", filename);
-		return 0;
+		/* Allow the loading of a non existing file */
+		if (global.tune.allow_non_existent_pattern_file) {
+			ha_notice("Pattern file <%s> was not found but loaded because 'tune.pattern.allow-non-existing-file' is enabled.\n", filename);
+			return 1;
+		}else {
+			memprintf(err, "failed to open pattern file <%s>", filename);
+			return 0;
+		}
 	}
 
 	/* now parse all patterns. The file may contain only one pattern per


### PR DESCRIPTION
To allow pure usage of the runtime API/LUA to add/remove entries in Maps/ACLs we should be able to load non-existing patterns. This make deploying easier as otherwise empty files needs to be created.

A notice is issued when this config option is used and every time a non-existing file is loaded.

Fixes: #2202