### PR TITLE
Fix build error on ppc64le: invalid parameter combination for AltiVec…

### DIFF
--- a/include/import/xxhash.h
+++ b/include/import/xxhash.h
@@ -4129,7 +4129,7 @@ XXH3_accumulate_512_vsx(  void* XXH_RESTRICT acc,
                     const void* XXH_RESTRICT secret)
 {
     /* presumed aligned */
-    unsigned long long* const xacc = (unsigned long long*) acc;
+    xxh_u64x2 const* const xacc = (xxh_u64x2 *) acc;
     xxh_u64x2 const* const xinput   = (xxh_u64x2 const*) input;   /* no alignment restriction */
     xxh_u64x2 const* const xsecret  = (xxh_u64x2 const*) secret;    /* no alignment restriction */
     xxh_u64x2 const v32 = { 32, 32 };


### PR DESCRIPTION
I got error haproxy with version 2.8.2:
[  246s] In file included from include/haproxy/xxhash.h:43:0,
[  246s]                  from src/ssl_sock.c:84:
[  246s] include/import/xxhash.h: In function 'XXH3_accumulate_512_vsx':
[  246s] include/import/xxhash.h:4148:9: error: invalid parameter combination for AltiVec intrinsic __builtin_vec_ld
[  246s]          xxh_u64x2 acc_vec        = vec_xl(0, xacc + 2 * i);
[  246s]          ^~~~~~~~~
[  246s] compilation terminated due to -Wfatal-errors.
[  246s] make: *** [Makefile:1027: src/ssl_sock.o] Error 1
[  246s] make: *** Waiting for unfinished jobs....
[  247s] In file included from include/haproxy/xxhash.h:43:0,
[  247s]                  from src/ssl_ocsp.c:84:
[  247s] include/import/xxhash.h: In function 'XXH3_accumulate_512_vsx':
[  247s] include/import/xxhash.h:4148:9: error: invalid parameter combination for AltiVec intrinsic __builtin_vec_ld
[  247s]          xxh_u64x2 acc_vec        = vec_xl(0, xacc + 2 * i);
[  247s]          ^~~~~~~~~
[  247s] compilation terminated due to -Wfatal-errors.
[  247s] make: *** [Makefile:1027: src/ssl_ocsp.o] Error 1

This patch fixes the build problem