### PR TITLE
BUG/MEDIUM: h1-htx: Ensure chunked parsing with full output buffer

### DIFF
--- a/src/h1_htx.c
+++ b/src/h1_htx.c
@@ -836,7 +836,7 @@ size_t h1_parse_msg_data(struct h1m *h1m, struct htx **dsthtx,
 {
 	size_t sz, total = 0;
 
-	if (b_data(srcbuf) == ofs || max <= sizeof(struct htx_blk))
+	if (b_data(srcbuf) == ofs)
 		return 0;
 
 	if (h1m->flags & H1_MF_CLEN) {


### PR DESCRIPTION
A previous fix to ensure that there is sufficient space on the output buffer to place parsed data (#2053) introduced an issue that if the output buffer is filled on a chunk boundary no data is parsed but the congested flag is not set due to the state not being H1_MSG_DATA.

The check to ensure that there is sufficient space in the output buffer is actually already performed in all downstream functions before it is used. This makes the early optimisation that avoids the state transition to H1_MSG_DATA needless.  Therefore, in order to allow the chunk parser to continue in this edge case we can simply remove the early check.  This ensures that the state can progress and set the congested flag correctly in the caller.

This patch fixes #2262. The upstream change that caused this logic error was backported as far as 2.5, therefore it makes sense to backport this fix back that far also.