### PR TITLE
BUG/MEDIUM: server-state: update server if the ports in config and state match

### DIFF
--- a/src/server_state.c
+++ b/src/server_state.c
@@ -511,7 +511,11 @@ static void srv_state_px_update(const struct proxy *px, int vsn, struct eb_root 
 		if (!node)
 			continue; /* next server */
 		st_line = eb64_entry(node, typeof(*st_line), node);
-		srv_state_srv_update(srv, vsn, st_line->params+4);
+		if (atoi(st_line->params[18]) == srv->svc_port &&
+			atoi(st_line->params[21]) == srv->check.port) {
+			/* only update if the ports in the config and the state still match */
+			srv_state_srv_update(srv, vsn, st_line->params+4);
+		}
 
 		/* the node may be released now */
 		eb64_delete(node);


### PR DESCRIPTION
BUG/MEDIUM: server-state: update server if the ports in config and state match

When `load-server-state-from-file` is enabled, and change the backend port or check port in the config file (without altering the backend name and server name), restarting haproxy will not apply the port number changes from the new config file. This will result in users being unable to connect to the backend using the new port.

The reason is that haproxy only uses the backend name and server name to decide whether to use state information. To fix the issue, we can only update the server info if the ports in the config and the state still match.

This patch should solve the issue #2103.