### PR TITLE
BUILD: solaris: fix redefinition of queue struct

### DIFF
--- a/include/haproxy/compat.h
+++ b/include/haproxy/compat.h
@@ -303,6 +303,12 @@ typedef struct { } empty_t;
 #define CLOCK_MONOTONIC_COARSE CLOCK_MONOTONIC_FAST
 #endif
 
+/* On Solaris, `queue` is a reserved name, so we redefine it here for now.
+ */
+#if defined(sun)
+#define queue _queue
+#endif
+
 #endif /* _HAPROXY_COMPAT_H */
 
 /*


### PR DESCRIPTION
Compilation on solaris fails because the name 'queue' is reserved:

> include/haproxy/queue-t.h:43:8: error: redefinition of ‘struct queue’

This patch redefines 'queue' as '_queue' which fixes compilation for now.

Future plan: rename 'queue' in code base so define can be removed again.

Backporting: 2.9, 2.8