### PR TITLE
BUILD: solaris: fix compilation errors

### DIFF
--- a/include/haproxy/compat.h
+++ b/include/haproxy/compat.h
@@ -303,6 +303,12 @@ typedef struct { } empty_t;
 #define CLOCK_MONOTONIC_COARSE CLOCK_MONOTONIC_FAST
 #endif
 
+/* On Solaris, `queue` is a reserved name, so we redefine it here for now.
+ */
+#if defined(sun)
+#define queue _queue
+#endif
+
 #endif /* _HAPROXY_COMPAT_H */
 
 /*

--- a/src/server.c
+++ b/src/server.c
@@ -4438,11 +4438,11 @@ int snr_resolution_cb(struct resolv_requester *requester, struct dns_counters *c
 
  update_status:
 	if (has_no_ip && !snr_set_srv_down(s)) {
-		struct server_inetaddr s_addr;
+		struct server_inetaddr srv_addr;
 
-		memset(&s_addr, 0, sizeof(s_addr));
+		memset(&srv_addr, 0, sizeof(srv_addr));
 		/* unset server's addr */
-		server_set_inetaddr(s, &s_addr, SERVER_INETADDR_UPDATER_NONE, NULL);
+		server_set_inetaddr(s, &srv_addr, SERVER_INETADDR_UPDATER_NONE, NULL);
 	}
 	return 1;
 
@@ -4452,11 +4452,11 @@ int snr_resolution_cb(struct resolv_requester *requester, struct dns_counters *c
 		goto update_status;
 	}
 	if (has_no_ip && !snr_set_srv_down(s)) {
-		struct server_inetaddr s_addr;
+		struct server_inetaddr srv_addr;
 
-		memset(&s_addr, 0, sizeof(s_addr));
+		memset(&srv_addr, 0, sizeof(srv_addr));
 		/* unset server's addr */
-		server_set_inetaddr(s, &s_addr, SERVER_INETADDR_UPDATER_NONE, NULL);
+		server_set_inetaddr(s, &srv_addr, SERVER_INETADDR_UPDATER_NONE, NULL);
 	}
 	return 0;
 }
@@ -4538,11 +4538,11 @@ int snr_resolution_error_cb(struct resolv_requester *requester, int error_code)
 
 	HA_SPIN_LOCK(SERVER_LOCK, &s->lock);
 	if (!snr_set_srv_down(s)) {
-		struct server_inetaddr s_addr;
+		struct server_inetaddr srv_addr;
 
-		memset(&s_addr, 0, sizeof(s_addr));
+		memset(&srv_addr, 0, sizeof(srv_addr));
 		/* unset server's addr */
-		server_set_inetaddr(s, &s_addr, SERVER_INETADDR_UPDATER_NONE, NULL);
+		server_set_inetaddr(s, &srv_addr, SERVER_INETADDR_UPDATER_NONE, NULL);
 		HA_SPIN_UNLOCK(SERVER_LOCK, &s->lock);
 		resolv_detach_from_resolution_answer_items(requester->resolution, requester);
 		return 0;


### PR DESCRIPTION
Compilation on solaris fails because of usage of names reserved on that platform, i.e. 'queue' and 's_addr'.

This patch redefines 'queue' as '_queue' and renames 's_addr' to 'srv_addr' which fixes compilation for now.

Future plan: rename 'queue' in code base so define can be removed again.

Backporting: 2.9, 2.8