### PR TITLE
Add destination ip as source ip

### DIFF
--- a/doc/configuration.txt
+++ b/doc/configuration.txt
@@ -11014,7 +11014,7 @@ server-template <prefix> <num | range> <fqdn>[:<port>] [params*]
 
 
 
-source <addr>[:<port>] [usesrc { <addr2>[:<port2>] | client | clientip } ]
+source <addr>[:<port>] [usesrc { <addr2>[:<port2>] | client | clientip | dstip } ]
 source <addr>[:<port>] [usesrc { <addr2>[:<port2>] | hdr_ip(<hdr>[,<occ>]) } ]
 source <addr>[:<port>] [interface <name>]
   Set the source address for outgoing connections

--- a/include/haproxy/connection-t.h
+++ b/include/haproxy/connection-t.h
@@ -259,6 +259,7 @@ enum {
 	CO_SRC_TPROXY_CIP  = 0x0002,    /* bind to the client's IP address when connecting */
 	CO_SRC_TPROXY_CLI  = 0x0003,    /* bind to the client's IP+port when connecting */
 	CO_SRC_TPROXY_DYN  = 0x0004,    /* bind to a dynamically computed non-local address */
+	CO_SRC_TPROXY_DIP  = 0x0005,    /* bind to the destination IP address when connecting */ 
 	CO_SRC_TPROXY_MASK = 0x0007,    /* bind to a non-local address when connecting */
 
 	CO_SRC_BIND        = 0x0008,    /* bind to a specific source address when connecting */

--- a/src/backend.c
+++ b/src/backend.c
@@ -1134,7 +1134,19 @@ int alloc_bind_address(struct sockaddr_storage **ss,
 
 		**ss = *addr;
 		break;
+	case CO_SRC_TPROXY_DIP:
+		BUG_ON(!s); /* Dynamic source setting requires a stream instance. */
 
+		/* FIXME: what can we do if the client connects in IPv6 or unix socket ? */
+		addr = sc_dst(s->scf);
+		if (!addr)
+			return SRV_STATUS_INTERNAL;
+
+		if (!sockaddr_alloc(ss, NULL, 0))
+			return SRV_STATUS_INTERNAL;
+
+		**ss = *addr;
+		break;
 	case CO_SRC_TPROXY_DYN:
 		BUG_ON(!s); /* Dynamic source setting requires a stream instance. */
 

--- a/src/cfgparse-listen.c
+++ b/src/cfgparse-listen.c
@@ -2771,6 +2771,9 @@ stats_error_parsing:
 				} else if (strcmp(args[cur_arg + 1], "clientip") == 0) {
 					curproxy->conn_src.opts &= ~CO_SRC_TPROXY_MASK;
 					curproxy->conn_src.opts |= CO_SRC_TPROXY_CIP;
+				}  else if (strcmp(args[cur_arg + 1], "dstip") == 0) {
+					curproxy->conn_src.opts &= ~CO_SRC_TPROXY_MASK;
+					curproxy->conn_src.opts |= CO_SRC_TPROXY_CIP;
 				} else if (!strncmp(args[cur_arg + 1], "hdr_ip(", 7)) {
 					char *name, *end;
 

--- a/src/cfgparse-listen.c
+++ b/src/cfgparse-listen.c
@@ -2759,7 +2759,7 @@ stats_error_parsing:
 			if (strcmp(args[cur_arg], "usesrc") == 0) {  /* address to use outside */
 #if defined(CONFIG_HAP_TRANSPARENT)
 				if (!*args[cur_arg + 1]) {
-					ha_alert("parsing [%s:%d] : '%s' expects <addr>[:<port>], 'client', or 'clientip' as argument.\n",
+					ha_alert("parsing [%s:%d] : '%s' expects <addr>[:<port>], 'client', 'clientip' or 'dst' as argument.\n",
 						 file, linenum, "usesrc");
 					err_code |= ERR_ALERT | ERR_FATAL;
 					goto out;

--- a/src/proto_quic.c
+++ b/src/proto_quic.c
@@ -384,6 +384,7 @@ int quic_connect_server(struct connection *conn, int flags)
 			case CO_SRC_TPROXY_ADDR:
 				flags = 3;
 				break;
+			case CO_SRC_TPROXY_DIP:
 			case CO_SRC_TPROXY_CIP:
 			case CO_SRC_TPROXY_DYN:
 				conn_set_private(conn);

--- a/src/proto_tcp.c
+++ b/src/proto_tcp.c
@@ -400,6 +400,7 @@ int tcp_connect_server(struct connection *conn, int flags)
 				flags = 3;
 				break;
 			case CO_SRC_TPROXY_CIP:
+			case CO_SRC_TPROXY_DIP:
 			case CO_SRC_TPROXY_DYN:
 				flags = 1;
 				break;

--- a/src/server.c
+++ b/src/server.c
@@ -1753,7 +1753,7 @@ static int srv_parse_source(char **args, int *cur_arg,
 		if (strcmp(args[*cur_arg], "usesrc") == 0) {  /* address to use outside */
 #if defined(CONFIG_HAP_TRANSPARENT)
 			if (!*args[*cur_arg + 1]) {
-				ha_alert("'usesrc' expects <addr>[:<port>], 'client', 'clientip', "
+				ha_alert("'usesrc' expects <addr>[:<port>], 'client', 'clientip', 'dstip',"
 					 "or 'hdr_ip(name,#)' as argument.\n");
 				goto err;
 			}
@@ -1764,6 +1764,10 @@ static int srv_parse_source(char **args, int *cur_arg,
 			else if (strcmp(args[*cur_arg + 1], "clientip") == 0) {
 				newsrv->conn_src.opts &= ~CO_SRC_TPROXY_MASK;
 				newsrv->conn_src.opts |= CO_SRC_TPROXY_CIP;
+			}
+			else if (strcmp(args[*cur_arg + 1], "dstip") == 0) {
+				newsrv->conn_src.opts &= ~CO_SRC_TPROXY_MASK;
+				newsrv->conn_src.opts |= CO_SRC_TPROXY_DIP;
 			}
 			else if (!strncmp(args[*cur_arg + 1], "hdr_ip(", 7)) {
 				char *name, *end;


### PR DESCRIPTION
When the Haproxy instance binds to multiple VIPs. We need a feature to identify the forwarded packet from Haproxy instance came from which VIP. Adding a feature to allow destinationip to bind as sourceIP in backend.

Allow the haproxy instance to transport the response packet with the Source IP as incoming request destination IP. 