### PR TITLE
Mptcp v1

### DIFF
--- a/doc/configuration.txt
+++ b/doc/configuration.txt
@@ -1341,6 +1341,7 @@ The following keywords are supported in the "global" section :
    - maxsslconn
    - maxsslrate
    - maxzlibmem
+   - mptcp
    - no-memory-trimming
    - noepoll
    - noevports
@@ -2957,6 +2958,10 @@ maxzlibmem <number>
   The default value is 0. The value is available in bytes on the UNIX socket
   with "show info" on the line "MaxZlibMemUsage", the memory used by zlib is
   "ZlibMemUsage" in bytes.
+
+mptcp
+  Enables the use of the Multipath TCP (MPTCP) protocol. This option is only
+  available when support for MPTCP was built in.
 
 no-memory-trimming
   Disables memory trimming ("malloc_trim") at a few moments where attempts are

--- a/doc/haproxy.1
+++ b/doc/haproxy.1
@@ -1,4 +1,4 @@
-.TH HAPROXY 1 "17 August 2007" 
+.TH HAPROXY 1 "17 August 2007"
 
 .SH NAME
 

--- a/include/haproxy/global-t.h
+++ b/include/haproxy/global-t.h
@@ -85,6 +85,7 @@
 #define GTUNE_LISTENER_MQ_OPT    (1<<28)
 #define GTUNE_LISTENER_MQ_ANY    (GTUNE_LISTENER_MQ_FAIR | GTUNE_LISTENER_MQ_OPT)
 #define GTUNE_QUIC_CC_HYSTART    (1<<29)
+#define GTUNE_MPTCP      		 (1<<30)
 
 #define NO_ZERO_COPY_FWD             0x0001 /* Globally disable zero-copy FF */
 #define NO_ZERO_COPY_FWD_PT          0x0002 /* disable zero-copy FF for PT (recv & send are disabled automatically) */

--- a/include/haproxy/global-t.h
+++ b/include/haproxy/global-t.h
@@ -85,7 +85,7 @@
 #define GTUNE_LISTENER_MQ_OPT    (1<<28)
 #define GTUNE_LISTENER_MQ_ANY    (GTUNE_LISTENER_MQ_FAIR | GTUNE_LISTENER_MQ_OPT)
 #define GTUNE_QUIC_CC_HYSTART    (1<<29)
-#define GTUNE_MPTCP      		 (1<<30)
+#define GTUNE_MPTCP              (1<<30)
 
 #define NO_ZERO_COPY_FWD             0x0001 /* Globally disable zero-copy FF */
 #define NO_ZERO_COPY_FWD_PT          0x0002 /* disable zero-copy FF for PT (recv & send are disabled automatically) */

--- a/src/cfgparse-global.c
+++ b/src/cfgparse-global.c
@@ -1335,10 +1335,10 @@ int cfg_parse_global(const char *file, int linenum, char **args, int kwm)
 		}
 	}
 	else if (strcmp(args[0], "mptcp") == 0) {
-        if (alertif_too_many_args(0, file, linenum, args, &err_code))
-            goto out;
+		if (alertif_too_many_args(0, file, linenum, args, &err_code))
+			goto out;
 		global.tune.options |= GTUNE_MPTCP;
-    }
+	}
 	else {
 		struct cfg_kw_list *kwl;
 		const char *best;

--- a/src/cfgparse-global.c
+++ b/src/cfgparse-global.c
@@ -1334,6 +1334,11 @@ int cfg_parse_global(const char *file, int linenum, char **args, int kwm)
 			HA_ATOMIC_STORE(&global.anon_key, tmp);
 		}
 	}
+	else if (strcmp(args[0], "mptcp") == 0) {
+        if (alertif_too_many_args(0, file, linenum, args, &err_code))
+            goto out;
+		global.tune.options |= GTUNE_MPTCP;
+    }
 	else {
 		struct cfg_kw_list *kwl;
 		const char *best;

--- a/src/listener.c
+++ b/src/listener.c
@@ -399,6 +399,11 @@ void stop_listener(struct listener *l, int lpx, int lpr, int lli)
  */
 void default_add_listener(struct protocol *proto, struct listener *listener)
 {
+	if(global.tune.options & GTUNE_MPTCP)
+		/* check MPTCP option */
+#ifdef linux
+		proto->sock_prot = IPPROTO_MPTCP;
+#endif
 	if (listener->state != LI_INIT)
 		return;
 	listener_set_state(listener, LI_ASSIGNED);


### PR DESCRIPTION
Multipath TCP (MPTCP), standardized in RFC8684 [1], is a TCP extension
that enables a TCP connection to use different paths.

Multipath TCP has been used for several use cases. On smartphones, MPTCP
enables seamless handovers between cellular and Wi-Fi networks while
preserving established connections. This use-case is what pushed Apple
to use MPTCP since 2013 in multiple applications [2]. On dual-stack
hosts, Multipath TCP enables the TCP connection to automatically use the
best performing path, either IPv4 or IPv6. If one path fails, MPTCP
automatically uses the other path.

To benefit from MPTCP, both the client and the server have to support
it. Multipath TCP is a backward-compatible TCP extension that is enabled
by default on recent Linux distributions (Debian, Ubuntu, Redhat, ...).
Multipath TCP is included in the Linux kernel since version 5.6 [3]. To
use it on Linux, an application must explicitly enable it when creating
the socket. No need to change anything else in the application.

This attached patch adds an mptcp option in the config which allows the 
creation of an MPTCP socket instead of TCP on Linux. If Multipath TCP 
is not supported on the system, an error will be reported and the start failed. 

Due to the limited impact within a data center environment, 
we have decided not to implement MPTCP between the proxy and the servers. 
The high-speed, low-latency nature of data center networks reduces 
the benefits of MPTCP, making the complexity of its implementation 
unnecessary in this context.

Link: https://www.rfc-editor.org/rfc/rfc8684.html [1]
Link: https://www.tessares.net/apples-mptcp-story-so-far/ [2]
Link: https://www.mptcp.dev [3]
Co-developed-by: Dorian Craps <doriancraps@gmail.com> @CrapsDorian
Co-developed-by: Olivier Bonaventure <Olivier.Bonaventure@uclouvain.be> @obonaventure
Co-developed-by: Matthieu Baerts <matttbe@kernel.org> @matttbe
Signed-off-by: Dorian Craps <dorian.craps@student.vinci.be>