### PR TITLE
FEATURE: Enhance handling of non-RFC conformant syslog messages

### DIFF
--- a/doc/configuration.txt
+++ b/doc/configuration.txt
@@ -5345,6 +5345,18 @@ maxconn <conns>
 timeout client <timeout>
   Set the maximum inactivity time on the client side.
 
+option dontparselog
+  Enables HAProxy to relay syslog messages without attempting to parse and
+  restructure them, useful for forwarding messages that may not conform to
+  traditional formats. This option should be used with the format raw setting on
+  destination log targets to ensure the original message content is preserved.
+
+option assume-rfc6587-ntf
+  Directs HAProxy to treat incoming TCP log streams always as using
+  non-transparent framing. This option simplifies the framing logic and ensures
+  consistent handling of messages, particularly useful when dealing with
+  improperly formed starting characters.
+
 3.11. HTTPClient tuning
 -----------------------
 

--- a/include/haproxy/proxy-t.h
+++ b/include/haproxy/proxy-t.h
@@ -161,6 +161,11 @@ enum PR_SRV_STATE_FILE {
 #define PR_O2_CHK_ANY   0xF0000000      /* Mask to cover any check */
 /* end of proxy->options2 */
 
+/* bits for proxy->options_log */
+#define PR_OL_DONTPARSELOG       0x00000001 /* don't parse log messages */
+#define PR_OL_ASSUME_RFC6587_NTF 0x00000002 /* assume that we are going to receive just non-transparent framing messages */
+/* end of proxy->options_log */
+
 /* Cookie settings for pr->ck_opts */
 #define PR_CK_RW        0x00000001      /* rewrite all direct cookies with the right serverid */
 #define PR_CK_IND       0x00000002      /* keep only indirect cookies */
@@ -285,6 +290,7 @@ struct proxy {
 
 	int options;				/* PR_O_REDISP, PR_O_TRANSP, ... */
 	int options2;				/* PR_O2_* */
+	int options_log;			/* PR_OL_* */
 	unsigned int ck_opts;			/* PR_CK_* (cookie options) */
 	unsigned int fe_req_ana, be_req_ana;	/* bitmap of common request protocol analysers for the frontend and backend */
 	unsigned int fe_rsp_ana, be_rsp_ana;	/* bitmap of common response protocol analysers for the frontend and backend */

--- a/include/haproxy/proxy.h
+++ b/include/haproxy/proxy.h
@@ -39,6 +39,7 @@ extern struct eb_root proxy_by_name;    /* tree of proxies sorted by name */
 
 extern const struct cfg_opt cfg_opts[];
 extern const struct cfg_opt cfg_opts2[];
+extern const struct cfg_opt cfg_opts_log[];
 
 struct task *manage_proxy(struct task *t, void *context, unsigned int state);
 void proxy_cond_pause(struct proxy *p);

--- a/src/log.c
+++ b/src/log.c
@@ -5376,6 +5376,24 @@ void app_log(struct list *loggers, struct buffer *tag, int level, const char *fo
 
 	__send_log(NULL, loggers, tag, level, logline, data_len, default_rfc5424_sd_log_format, 2);
 }
+
+/*
+ * This function sets up the initial state for a log message by preparing
+ * the buffer, setting default values for the log level and facility, and
+ * initializing metadata fields. It is used before parsing or constructing
+ * a log message to ensure all fields are in a known state.
+ */
+void prepare_log_message(char *buf, size_t buflen, int *level, int *facility,
+												 struct ist *metadata, char **message, size_t *size)
+{
+	*level = *facility = -1;
+
+	*message = buf;
+	*size = buflen;
+
+	memset(metadata, 0, LOG_META_FIELDS*sizeof(struct ist));
+}
+
 /*
  * This function parse a received log message <buf>, of size <buflen>
  * it fills <level>, <facility> and <metadata> depending of the detected
@@ -5391,13 +5409,6 @@ void parse_log_message(char *buf, size_t buflen, int *level, int *facility,
 
 	char *p;
 	int fac_level = 0;
-
-	*level = *facility = -1;
-
-	*message = buf;
-	*size = buflen;
-
-	memset(metadata, 0, LOG_META_FIELDS*sizeof(struct ist));
 
 	p = buf;
 	if (*size < 2 || *p != '<')
@@ -5746,6 +5757,8 @@ void syslog_fd_handler(int fd)
 			_HA_ATOMIC_INC(&cum_log_messages);
 			proxy_inc_fe_req_ctr(l, l->bind_conf->frontend, 0);
 
+			prepare_log_message(buf->area, buf->data, &level, &facility, metadata, &message, &size);
+
 			parse_log_message(buf->area, buf->data, &level, &facility, metadata, &message, &size);
 
 			process_send_log(NULL, &l->bind_conf->frontend->loggers, level, facility, metadata, message, size);
@@ -5857,6 +5870,8 @@ static void syslog_io_handler(struct appctx *appctx)
 		/* update counters */
 		_HA_ATOMIC_INC(&cum_log_messages);
 		proxy_inc_fe_req_ctr(l, frontend, 0);
+
+		prepare_log_message(buf->area, buf->data, &level, &facility, metadata, &message, &size);
 
 		parse_log_message(buf->area, buf->data, &level, &facility, metadata, &message, &size);
 

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -134,6 +134,13 @@ const struct cfg_opt cfg_opts2[] =
 	{ NULL, 0, 0, 0 }
 };
 
+/* proxy->options_log */
+const struct cfg_opt cfg_opts_log[] = {
+	{"dontparselog",				PR_OL_DONTPARSELOG, PR_CAP_FE, 0, PR_MODE_SYSLOG },
+	{"assume-rfc6587-ntf",	PR_OL_ASSUME_RFC6587_NTF, PR_CAP_FE, 0, PR_MODE_SYSLOG },
+	{ NULL, 0, 0, 0 }
+};
+
 /* Helper function to resolve a single sticking rule after config parsing.
  * Returns 1 for success and 0 for failure
  */


### PR DESCRIPTION
Hi!

As discussed few weeks ago in issue #2856 , this is a PR that adds two useful options to the log-forward section.

```
option dontparselog
  Enables HAProxy to relay syslog messages without attempting to parse and
  restructure them, useful for forwarding messages that may not conform to
  traditional formats. This option should be used with the format raw setting on
  destination log targets to ensure the original message content is preserved.

option assume-rfc6587-ntf
  Directs HAProxy to treat incoming TCP log streams always as using
  non-transparent framing. This option simplifies the framing logic and ensures
  consistent handling of messages, particularly useful when dealing with
  improperly formed starting characters.
```

Thanks a lot in advance for taking this into consideration.
Best,

  Rober

 