### PR TITLE
Adding 'sb' instruction for spin_delay for ARM v8.5 onward

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -992,7 +992,7 @@ OBJS += src/mux_h2.o src/mux_h1.o src/mux_fcgi.o src/log.o		\
         src/ebsttree.o src/freq_ctr.o src/systemd.o src/init.o		\
         src/http_acl.o src/dict.o src/dgram.o src/pipe.o		\
         src/hpack-huff.o src/hpack-enc.o src/ebtree.o src/hash.o	\
-        src/version.o
+        src/spin_delay_arm.o src/version.o
 
 ifneq ($(TRACE),)
   OBJS += src/calltrace.o

--- a/include/haproxy/atomic.h
+++ b/include/haproxy/atomic.h
@@ -24,6 +24,7 @@
 #define _HAPROXY_ATOMIC_H
 
 #include <haproxy/compiler.h>
+#include <haproxy/spin_delay_arm.h>
 
 /* A few notes for the macros and functions here:
  *  - this file is painful to edit, most operations exist in 2 variants,
@@ -589,10 +590,10 @@ __ha_barrier_atomic_full(void)
 /* short-lived CPU relaxation; this was shown to improve fairness on
  * modern ARMv8 cores such as Neoverse N1.
  */
-#define __ha_cpu_relax() ({ asm volatile("isb" ::: "memory"); 1; })
+#define __ha_cpu_relax() ({ spin_delay_arm(); 1; })
 
 /* aarch64 prefers to wait for real in read loops */
-#define __ha_cpu_relax_for_read() ({ asm volatile("isb" ::: "memory"); 1; })
+#define __ha_cpu_relax_for_read() ({ spin_delay_arm(); 1; })
 
 #if defined(__ARM_FEATURE_ATOMICS) && !defined(__clang__) // ARMv8.1-A atomics
 

--- a/include/haproxy/spin_delay_arm.h
+++ b/include/haproxy/spin_delay_arm.h
@@ -1,0 +1,21 @@
+#ifndef _HAPROXY_SPIN_DELAY_ARM_H
+#define _HAPROXY_SPIN_DELAY_ARM_H
+
+#include "haproxy/compiler.h"
+
+/* Global variable to track SB support */
+extern int arm_has_sb_instruction;
+
+#if defined(__aarch64__) || defined(__arm64__)
+
+/* Use SB instruction if available, otherwise ISB */
+static inline void spin_delay_arm(void) {
+	if (__builtin_expect(arm_has_sb_instruction == 1, 1)) {
+		asm volatile(".inst 0xd50330ff");   /* SB instruction encoding */
+	} else {
+		asm volatile("isb");
+	}
+}
+
+#endif /* defined(__aarch64__) || defined(__arm64__) */
+#endif /* _HAPROXY_SPIN_DELAY_ARM_H */

--- a/include/import/atomic-ops.h
+++ b/include/import/atomic-ops.h
@@ -23,6 +23,8 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
+ #include <haproxy/spin_delay_arm.h>
+
 #ifndef PL_ATOMIC_OPS_H
 #define PL_ATOMIC_OPS_H
 
@@ -756,7 +758,7 @@
 
 /* This was shown to improve fairness on modern ARMv8 such as Neoverse N1 */
 #define pl_cpu_relax() do {				\
-		asm volatile("isb" ::: "memory");	\
+		spin_delay_arm();	            \
 	} while (0)
 
 /* full/load/store barriers */

--- a/include/import/mt_list.h
+++ b/include/import/mt_list.h
@@ -32,6 +32,7 @@
 
 #include <inttypes.h>
 #include <stddef.h>
+#include <haproxy/spin_delay_arm.h>
 
 #if defined(__TINYC__)
 /* TCC has __atomic_exchange() for gcc's __atomic_exchange_n(). However it does
@@ -233,7 +234,7 @@ static inline __attribute__((always_inline)) unsigned long mt_list_cpu_relax(uns
 		/* This was shown to improve fairness on modern ARMv8
 		 * such as Cortex A72 or Neoverse N1.
 		 */
-		asm volatile("isb");
+		spin_delay_arm();
 #else
 		/* Generic implementation */
 		asm volatile("");

--- a/src/spin_delay_arm.c
+++ b/src/spin_delay_arm.c
@@ -1,0 +1,20 @@
+#include "haproxy/compiler.h"
+#include "haproxy/spin_delay_arm.h"
+
+/* Initialize to 0 (false) by default */
+int arm_has_sb_instruction = 0;
+
+#if defined(__linux__) && (defined(__aarch64__) || defined(__arm64__)) && \
+	(defined(__GNUC__) || defined(__clang__))
+#include <sys/auxv.h>
+
+#ifndef HWCAP_SB
+#define HWCAP_SB		(1 << 29)
+#endif  // HWCAP_SB
+
+__attribute__((constructor))
+void detect_arm_sb_support(void) {
+    arm_has_sb_instruction = (getauxval(AT_HWCAP) & HWCAP_SB) ? 1 : 0;
+}
+
+#endif


### PR DESCRIPTION
We would like to propose this optimization for ARM architecture that, at runtime, it switches to SB instruction if supported by the system. SB (Speculation Barrier) is a modern barrier which is available from armv8.5a. It achieves the same result as issuing ISB, but instead of flushing the CPU it does so by serializing older instructions to be non-speculative before it completes. This is less disruptive than an "isb" to high performance CPUs.

We already saw positive improvements on MySQL server (https://github.com/mysql/mysql-server/pull/611) and Folly (https://github.com/facebook/folly/pull/2390) implementations.