### PR TITLE
Fix reg-tests curve check

### DIFF
--- a/reg-tests/ssl/ssl_generate_certificate.vtc
+++ b/reg-tests/ssl/ssl_generate_certificate.vtc
@@ -165,7 +165,7 @@ client c6 -connect ${h1_clearlst_sock} {
 # The curve with the highest priority is X25519 for OpenSSL 1.1.1 and later,
 # and P-256 for OpenSSL 1.0.2.
 shell {
-    echo "Q" | openssl s_client -unix "${tmpdir}/ssl.sock" -servername server.ecdsa.com -tls1_2 2>/dev/null | grep -E "Server Temp Key: (ECDH, P-256, 256 bits|ECDH, prime256v1, 256 bits|X25519, 253 bits)"
+    echo "Q" | openssl s_client -unix "${tmpdir}/ssl.sock" -servername server.ecdsa.com -tls1_2 2>/dev/null | grep -E "(Server|Peer) Temp Key: (ECDH, P-256, 256 bits|ECDH, prime256v1, 256 bits|X25519, 253 bits)"
 }
 
 shell {


### PR DESCRIPTION
OpenSSL changed the output from "Server Temp Key" in prior versions to "Peer Temp Key" in recent ones.
https://github.com/openssl/openssl/commit/a39dc27c2573da14e85ca8961970c82009bd4ff6 It looks like it affects OpenSSL >=3.5.0
This broke the reg-test for e.g. Debian 13 builds, using OpenSSL 3.5.1

Fixes bug #3238